### PR TITLE
Add userTransaction in get_started_faster_with_forge.textile

### DIFF
--- a/guides/get_started_faster_with_forge.textile
+++ b/guides/get_started_faster_with_forge.textile
@@ -374,6 +374,6 @@ You can find the exported archive in the project's target directory.
 bc(command). $ cd ~~
 $ ls target/*.jar
 
-bc(output). arquillian-demo.jar
+bc(output). test.jar
 
 If you inspect that jar file using an archive program, you'll find that it matches the ShrinkWrap archive you defined in the @@Deployment@ method of the test.

--- a/guides/get_started_faster_with_forge.textile
+++ b/guides/get_started_faster_with_forge.textile
@@ -246,12 +246,16 @@ public class LanguageDao {
     @PersistenceContext
     EntityManager em;
 
+	@Inject
+    UserTransaction transaction;
+
     public List<Language> listLanguages() {
         return em.createQuery("select l from Language l").getResultList();
     }
 
     @PostConstruct
     public void insertTestData() {
+		transaction.begin();
         Language java = new Language();
         java.setName("Java");
         em.persist(java);
@@ -263,6 +267,7 @@ public class LanguageDao {
         Language groovy = new Language();
         groovy.setName("Groovy");
         em.persist(groovy);
+		transaction.commit();
     }
 }
 


### PR DESCRIPTION
Add userTransaction to begin and commit the transaction to avoid javax.persistence.TransactionRequiredException

Without injection of userTransaction to begin and commit, i got the error as follows:

```
Caused by: javax.persistence.TransactionRequiredException: JBAS011469: Transaction is required to perform this operation (either use a transaction or extended persistence context)
    at org.jboss.as.jpa.container.AbstractEntityManager.transactionIsRequired(AbstractEntityManager.java:692)
    at org.jboss.as.jpa.container.AbstractEntityManager.persist(AbstractEntityManager.java:562)
    at demo.LanguageDao.insertTestData(LanguageDao.java:42)
    ... 98 more
```
