### PR TITLE
At Line 217,there is a fault for a forge command

### DIFF
--- a/guides/getting_started.textile
+++ b/guides/getting_started.textile
@@ -214,7 +214,7 @@ bc(command). [arquillian-tutorial] arquillian-tutorial $
 
 What we need to add now is the Java EE APIs. That's done using the @project add-dependency@ command below:
 
-bc(command). $ project-add-dependencies org.jboss.spec:jboss-javaee-7.0:1.0.3.Final:provided:pom
+bc(command). $ project-add-dependencies org.jboss.spec:jboss-javaee-7.0:1.0.3.Final:pom:provided
 
 You'll also need to add JUnit 4.12, the minimum required version of JUnit to use Arquillian, as a test-scoped dependency:
 


### PR DESCRIPTION
Hello author:
      there is a fault for a command at line 217 which is "$ project-add-dependencies org.jboss.spec:jboss-javaee-6.0:1.0.0.Final:pom:provided ",perhaps when i execute this command, this project's pom.xml has an error , like:
      "<type>provided</type>; <scope>pom</scope>",so i changed this command like"~Final:provided:pom",then, it's right.

<!-- 
Many thanks for contributing to Arquillian! Together we can make the testing world better.

Please tell us what this PR brings following the template we provided. 
And don't forget to link to the issue (or create one if there is none).

If you are still working on the change please prefix this pull request title with "WIP"

YOU CAN DELETE THIS COMMENT :)
-->

#### Short description of what this resolves:


#### Changes proposed in this pull request:

-
-
-


**Fixes**: #
