### PR TITLE
Labeled Forge guide translations as drafts

### DIFF
--- a/_ext/guide.rb
+++ b/_ext/guide.rb
@@ -97,17 +97,20 @@ module Awestruct
               #puts "#{trans_base_name} #{trans_lang} #{trans_postfix}"
 
               trans_page = page.site.pages.find { |e| e.source_path =~ /.*#{trans_base_name}_#{trans_lang}.#{trans_postfix}/ }
-
-              trans_page.language_parent = page
-              trans_page.language = page.site.languages.send(trans_lang)
-              trans_page.language.code = trans_lang
-              if !trans_page.translators.nil?
-                trans_page.translators.each do |username|
-                  page.site.identities.lookup(username).translator = true
+	      if !trans_page.nil?
+                trans_page.language_parent = page
+                trans_page.language = page.site.languages.send(trans_lang)
+                trans_page.language.code = trans_lang
+                if !trans_page.translators.nil?
+                  trans_page.translators.each do |username|
+                    page.site.identities.lookup(username).translator = true
+                  end
                 end
-              end
 
-              languages << trans_page
+                languages << trans_page
+              else
+               puts "The #{trans_lang} translation for the page #{trans_base_name} won't be added"
+	      end
             end
           end
           return languages.sort { |a, b| a.language.code <=> b.language.code }

--- a/guides/get_started_faster_with_forge_de.textile
+++ b/guides/get_started_faster_with_forge_de.textile
@@ -1,10 +1,14 @@
 ---
+draft: true
 layout: guide
 title: Schneller Starten mit Forge
 authors: [paulbakker, lincolnthree]
 translators: [myfear, bennetelli]
 description: Lerne wie Forge Dir hilft, noch schneller mit Arquillian zu starten und Deine Tests noch effizienter zu entwickeln.
 ---
+
+h1. WARNING: This guide is labeled as a draft (will be visible only in the development mode) as it is a translation of an older version of the "Get Started Faster with Forge" guide.
+
 Dieser Guide macht Dich vertraut mit dem Arquillian Plugin für JBoss Forge. Nach dem Lesen bist Du in der Lage:
 
 * Das Arquillian Plugin Deiner Forge Installation hinzuzufügen.

--- a/guides/get_started_faster_with_forge_el_gr.textile
+++ b/guides/get_started_faster_with_forge_el_gr.textile
@@ -1,4 +1,5 @@
 ---
+draft: true
 layout: guide
 title: Ταχύτερη εξοικείωση με τη χρήση του Forge
 authors: [paulbakker, lincolnthree]
@@ -7,6 +8,9 @@ description: Μάθε πως να χρησιμοποιείς το JBoss Forge ώ
 guide_group: 1
 guide_order: 30
 ---
+
+h1. WARNING: This guide is labeled as a draft (will be visible only in the development mode) as it is a translation of an older version of the "Get Started Faster with Forge" guide.
+
 Ο οδηγός αυτός στοχεύει στην εξοικείωση με το Arquillian plugin για το JBoss Forge. Με την ολοκλήρωση του οδηγού, θα είσαι σε θέση να:
 
 * Εγκαταστήσεις το Arquillian plugin στο Forge

--- a/guides/get_started_faster_with_forge_it.textile
+++ b/guides/get_started_faster_with_forge_it.textile
@@ -1,4 +1,5 @@
 ---
+draft: true
 layout: guide
 title: Guida introduttiva e rapida per Forge
 authors: [paulbakker, lincolnthree]
@@ -7,6 +8,9 @@ description: Impariamo ad usare JBoss Forge con Arquillian e a sviluppare i test
 guide_group: 1
 guide_order: 30
 ---
+
+h1. WARNING: This guide is labeled as a draft (will be visible only in the development mode) as it is a translation of an older version of the "Get Started Faster with Forge" guide.
+
 Questa guida permetterà di avere familiarità con il plugin Arquillian per JBoss Forge. Terminata la lettura potremo:
 
 * Aggiungere il plugin Arquilian nella tua installazione di Forge

--- a/guides/get_started_faster_with_forge_ja.textile
+++ b/guides/get_started_faster_with_forge_ja.textile
@@ -1,4 +1,5 @@
 ---
+draft: true
 layout: guide
 title: Get Started Faster with Forge
 authors: [paulbakker, lincolnthree]
@@ -6,6 +7,9 @@ translators: [leathersole]
 description: Arquillianをすぐに始められるように、またより効率よくテストを作成できるように、JBoss Forgeの使い方を学びます。
 reference_rev: 52f8fbd2ff5f00fbbd70729a40f1d6ab124e600e
 ---
+
+h1. WARNING: This guide is labeled as a draft (will be visible only in the development mode) as it is a translation of an older version of the "Get Started Faster with Forge" guide.
+
 このガイドでは、JBoss ForgeのArquillianプラグインについて解説します。このガイドを読むと、以下のことができるようになります：
 
 * Forge環境にArquillainプラグインをインストールする

--- a/guides/get_started_faster_with_forge_pl.textile
+++ b/guides/get_started_faster_with_forge_pl.textile
@@ -1,4 +1,5 @@
 ---
+draft: true
 layout: guide
 title: Zacznij jeszcze szybciej z Forge
 authors: [paulbakker, lincolnthree]
@@ -7,6 +8,9 @@ description: Naucz się jak pisać testy Arquilliana szybciej i być bardziej ef
 guide_group: 1
 guide_order: 30
 ---
+
+h1. WARNING: This guide is labeled as a draft (will be visible only in the development mode) as it is a translation of an older version of the "Get Started Faster with Forge" guide.
+
 Dzięki temu wprowadzeniu zaznajomisz się z pluginem Arquilliana dla JBoss Forge. Po lekturze będziesz potrafił:
 
 * Dodać plugin Arquilliana dla swojej instalacji Forge.

--- a/guides/get_started_faster_with_forge_pt.textile
+++ b/guides/get_started_faster_with_forge_pt.textile
@@ -1,4 +1,5 @@
 ---
+draft: true
 layout: guide
 title: Começando rápido com o Forge
 authors: [paulbakker, lincolnthree]
@@ -7,6 +8,9 @@ description: Aprenda como usar o JBoss Forge para começar mais rápido os teste
 guide_group: 1
 guide_order: 30
 ---
+
+h1. WARNING: This guide is labeled as a draft (will be visible only in the development mode) as it is a translation of an older version of the "Get Started Faster with Forge" guide.
+
 Este guia irá te familiar com o plugin do Arquillian para o JBoss Forge. Depois de ler este guia, você será capaz de:
 
 * Instalar o plugin do Arquillian na sua instalação do Forge;

--- a/guides/get_started_faster_with_forge_zh_cn.textile
+++ b/guides/get_started_faster_with_forge_zh_cn.textile
@@ -1,4 +1,5 @@
 ---
+draft: true
 layout: guide
 title: 快速入门：使用 Forge 
 authors: [paulbakker, lincolnthree]
@@ -6,6 +7,9 @@ translators: [hantsy]
 description: 学习如何在 JBoss Forge 中更快速和高效使用 Arquillian 进行测试。
 reference_rev: 52f8fbd2ff5f00fbbd70729a40f1d6ab124e600e
 ---
+
+h1. WARNING: This guide is labeled as a draft (will be visible only in the development mode) as it is a translation of an older version of the "Get Started Faster with Forge" guide.
+
 本教程让你熟悉使用 JBoss Forge 的 Arquillian 插件。 阅读本教程后，你能够掌握：
 
 * 安装 Arquillian 插件到 Forge 环境中


### PR DESCRIPTION
And added small modification/fix to skip adding of not-generated (drafted) page translations