### PR TITLE
Typos, commas, hypens

### DIFF
--- a/guides/getting_started_de.textile
+++ b/guides/getting_started_de.textile
@@ -4,7 +4,7 @@ title: Erste Schritte
 authors: [mojavelinux]
 translators: [myfear, bennetelli]
 tags: [cdi, weld, maven, forge, eclipse]
-description: Lerne, wie Du die Arquillian Testsuite zu Deinem Projekt hinzufügst und die ersten Arquillian Tests schreibst.
+description: Lerne, wie Du die Arquillian-Testsuite zu Deinem Projekt hinzufügst und die ersten Arquillian-Tests schreibst.
 reference_rev: 52f8fbd2ff5f00fbbd70729a40f1d6ab124e600e
 ---
 [forge_home]http://jboss.org/forge
@@ -20,40 +20,39 @@ reference_rev: 52f8fbd2ff5f00fbbd70729a40f1d6ab124e600e
 
 Dieser Guide stellt Arquillian vor. Nach dem Lesen dieses Guides kannst Du:
 
-* Arquillian zu einem Maven basierten Projekt hinzufügen
-* einen Arquillian Testcase schreiben der das Verhalten eines CDI (Context and Dependency Injection) Beans überprüft.
-* den Arquillian Testcase in verschiedenen Containern ausführen.
+* Arquillian zu einem Maven-basierten Projekt hinzufügen
+* einen Arquillian-Testfall schreiben, der das Verhalten eines CDI- (Context and Dependency Injection) Beans überprüft.
+* den Arquillian-Testfall in verschiedenen Containern ausführen.
 
-Du wirst all dies lernen indem du Arquillian als Testsuite zu einem Java EE basierten Maven Projekt hinzufügst. Wir haben diesen Guide so entworfen,
-dass du ihn schnell durcharbeiten und sofort starten kannst!
+Du wirst all dies lernen, indem du Arquillian als Testsuite zu einem Java-EE-basierten Maven-Projekt hinzufügst. Wir haben diesen Guide so entworfen, dass du ihn schnell durcharbeiten und sofort starten kannst!
 
 h3. Annahmen
 
-Der einfachste Weg, mit Arquillian anzufangen ist, wenn man es in ein Projekt integriert welches bereits Abhängigkeitsmanagement (Dependency Management) unterstützt. Das am weitesten Verbreitete Werkzeug dieser Kategorie heutzutage ist "Apache Maven":maven_home. Dieser Guide führt Dich zu Deiner ersten *(greenbar)green bar* (grüner Testbalken) mithilfe eines Beispiel Maven Projekts.
+Der einfachste Weg mit Arquillian anzufangen ist, wenn man es in ein Projekt integriert, welches bereits Abhängigkeitsmanagement (Dependency Management) unterstützt. Das am weitesten Verbreitete Werkzeug dieser Kategorie heutzutage ist "Apache Maven":maven_home. Dieser Guide führt Dich zu Deiner ersten *(greenbar)green bar* (grüner Testbalken) mithilfe eines Beispiel-Maven-Projekts.
 
-p(info). %Arquillian basiert nicht auf Maven oder irgendeinem anderen Build-Tool. Es funktioniert genauso gut --wenn nicht besser-- wenn es in einem Projekt verwendet wird, welches einen Ant oder Gradle build einsetzt. Idealerweise sollte das Build-Werkzeug allerdings Dependency Management anbieten, da es die Integration der Arquillian Bibliotheken deutlich vereinfacht, weil diese bereits im "Maven Central repository":maven_search vorliegen.%
+p(info). %Arquillian basiert nicht auf Maven oder irgendeinem anderen Build-Tool. Es funktioniert genauso gut -- wenn nicht besser -- wenn es in einem Projekt verwendet wird, welches einen Ant- oder Gradle-Build einsetzt. Idealerweise sollte das Build-Werkzeug allerdings Dependency Management anbieten, da es die Integration der Arquillian-Bibliotheken deutlich vereinfacht, weil diese bereits im "Maven Central repository":maven_search vorliegen.%
 
-Dieser Guide setzt voraus, dass bei Dir Maven installiert ist. Entweder als Kommando-Zeilen Werkzeug oder in Deiner IDE (Integrated Development Environment). Wenn nicht, bitte "installiere Maven jetzt":maven_download. Du wirst auch ein "JDK(Java Development Kit)":jdk_download auf Deinem Rechner benötigen.
+Dieser Guide setzt voraus, dass bei Dir Maven installiert ist: Entweder als Kommandozeilenwerkzeug oder in Deiner IDE (Integrated Development Environment). Wenn nicht, bitte "installiere Maven jetzt":maven_download. Du wirst auch ein "JDK(Java Development Kit)":jdk_download auf Deinem Rechner benötigen.
 
 h3. Erstelle ein neues Projekt
 
-Es gibt zwei von uns empfohlene Wege ein neues Maven Projekt zu erstellen:
+Es gibt zwei von uns empfohlene Wege ein neues Maven-Projekt zu erstellen:
 
-# "Erstelle ein Projekt von einem Maven archetype":#generate_project_from_archetype
+# "Erstelle ein Projekt von einem Maven-Archetype":#generate_project_from_archetype
 # "Erstelle und passe ein Projekt mit JBoss Forge an":#create_project_using_forge
 
-Die Verwendung von "JBoss Forge":forge_home stellt den mit Abstand einfacheren Weg dar. Dieser Guide bietet dir allerdings beide Alternativen an, für den Fall dass du noch nicht bereit bist JBoss Forge einzusetzen. Wähle eine der obigen Optionen um zur jeweiligen Anleitung zu springen.
+Die Verwendung von "JBoss Forge":forge_home stellt den mit Abstand einfacheren Weg dar. Dieser Guide bietet dir allerdings beide Alternativen an, für den Fall, dass du noch nicht bereit bist JBoss Forge einzusetzen. Wähle eine der obigen Optionen, um zur jeweiligen Anleitung zu springen.
 
-p(info). %Wenn Du bereits ein Maven basiertes Projekt hast, kannst Du diese Sektion als Referenz verwenden um sicherzustellen, dass Du die richtigen Abhängigkeiten im Projekt hast bevor Du weitermachst.%
+p(info). %Wenn Du bereits ein Maven-basiertes Projekt hast, kannst Du diese Sektion als Referenz verwenden, um sicherzustellen, dass Du die richtigen Abhängigkeiten im Projekt hast, bevor Du weitermachst.%
 
-h4(#generate_project_from_archetype). Erstelle ein Projekt von einem Maven Archetype
+h4(#generate_project_from_archetype). Erstelle ein Projekt von einem Maven-Archetype aus
 
-Zuerst erstelle ein Maven basiertes Java Projekt mithilfe der Kommando-Zeile unten.
+Zuerst erstelle ein Maven-basiertes Java-Projekt mithilfe der Kommandozeile unten.
 
 bc(command).. $ mvn archetype:generate -DarchetypeGroupId=net.avh4.mvn.archetype \
 -DarchetypeArtifactId=java-1.6-archetype
 
-p. Kopiere den Text nach dem @$@ und füge ihn in deine Kommando-Zeilen-Fenster ein. Füge, wenn Du dazu aufgefordert wirst die in der folgen Liste stehenden Werte ein und bestätige sie mit @<ENTER>@.
+p. Kopiere den Text nach dem @$@ und füge ihn in deine Kommandozeilen-Fenster ein. Füge, wenn Du dazu aufgefordert wirst, die in der folgen Liste stehenden Werte ein und bestätige sie mit @<ENTER>@.
 
 bc(output). Define value for property 'groupId': : org.arquillian.example <ENTER>
 Define value for property 'artifactId': : arquillian-tutorial <ENTER>
@@ -66,26 +65,26 @@ version: 1.0-SNAPSHOT
 package: org.arquillian.example
 Y: : <ENTER>
 
-p. Dieses Kommando erzeugt ein Maven basiertes Java Projekt innerhalb eines Verzeichnisses mit dem Namen @arquillian-tutorial@ unterhalb des aktuellen Verzeichnisses. Die Dateistruktur des Projekt ist wie folgt:
+p. Dieses Kommando erzeugt ein Maven-basiertes Java-Projekt innerhalb eines Verzeichnisses mit dem Namen @arquillian-tutorial@ unterhalb des aktuellen Verzeichnisses. Die Dateistruktur des Projekt ist wie folgt:
 
 (Dateibaum)* src/
 ** main/
-*** java/ - Hier kommen alle Java Source Dateien hin (in Java Packages)
+*** java/ - Hier kommen alle Java-Sourcedateien hin (in Java-Packages)
 *** resources/ - Hier kommen alle Konfigurationsdateien der Anwendung hin.
 ** test/
-*** java/ - Hier kommen alle Test Java Source Dateien hin (in Java Packages)
-*** resources/ - Hier kommen alle Konfigurationsdateien der für die Tests hin, (beispielsweise: arquillian.xml)
-* pom.xml - Die Maven Build Datei, welche Maven sagt, wie das Projekt zu bauen ist.
+*** java/ - Hier kommen alle Test-Java-Sourcedateien hin (in Java-Packages)
+*** resources/ - Hier kommen alle Konfigurationsdateien für die Tests hin (beispielsweise: arquillian.xml)
+* pom.xml - Die Maven-Builddatei, welche Maven sagt, wie das Projekt zu bauen ist.
 
-p(info). %Das erzeugte Projekt ist mit Java 1.6 und JUnit 4.8 vorkonfiguriert. Dies sind die im Minimum benötigten Versionen von Java und JUnit um Arquillian zu nutzen.%
+p(info). %Das erzeugte Projekt ist mit Java 1.6 und JUnit 4.8 vorkonfiguriert. Dies sind die im Minimum benötigten Versionen von Java und JUnit, um Arquillian zu nutzen.%
 
-Der Generator hat auch ein Java Package mit dem Namen @org.arquillian.example@ unterhalb der beiden @java@ Verzeichnisse erstellt. Dorthin solltest Du auch Deine Java Sourcen packen und nicht direkt in das Root der @java@ Verzeichnisse.
+Der Generator hat auch ein Java-Package mit dem Namen @org.arquillian.example@ unterhalb der beiden @java@-Verzeichnisse erstellt. Dorthin solltest Du auch Deine Java-Sourcen packen und nicht direkt in das Root der @java@-Verzeichnisse.
 
 p(warning). %Arquillian unterstützt auch TestNG 5. Dennoch verwendet dieser Guide JUnit als Beispiel.%
 
-Öffnet als nächstes das @pom.xml@ in Deiner IDE oder einem Editor. Du solltest eine XML Datei mit den basis Projekt Informationen, einer @<build>@ und einer @<dependencies>@ section sehen. *Du kannst alle @<dependency>@ Elemente unterhalb der JUnit Abhängigkeit entfernen. Sie werden nicht benötigt.*
+Öffnet als nächstes das @pom.xml@ in Deiner IDE oder einem Editor. Du solltest eine XML-Datei mit den Basisprjektiformationen, einer @<build>@-und einer @<dependencies>@-Section sehen. *Du kannst alle @<dependency>@-Elemente unterhalb der JUnit-Abhängigkeit entfernen. Sie werden nicht benötigt.*
 
-Wenn Du fertig bist, sollte das Ergebnis ungefähr so aussehen (Abgekürzt zur besseren Lesbarkeit):
+Wenn Du fertig bist, sollte das Ergebnis ungefähr so aussehen (abgekürzt zur besseren Lesbarkeit):
 
 div(filename). pom.xml
 
@@ -132,9 +131,9 @@ bc(prettify).. <?xml version="1.0" encoding="UTF-8"?>
     </dependencies>
 </project>
 
-p. Wir werden Java EE 7 Komponenten schreiben. Daher benötigst Du außerdem die Java EE 7 API als abhängige Bibliothek im Classpath um diese kompilieren zu können.
+p. Wir werden Java-EE-7-Komponenten schreiben. Daher benötigst Du außerdem die Java-EE-7-API als abhängige Bibliothek im Classpath, um diese kompilieren zu können.
 
-Öffne erneut die @pom.xml@ Datei und füge das folgende XML Fragment direkt innerhalb der umschließenden @<dependencies>@ Elemente ein. Das sollte dann so aussehen, wenn Du fertig bist:
+Öffne erneut die @pom.xml@-Datei und füge das folgende XML-Fragment direkt innerhalb der umschließenden @<dependencies>@-Elemente ein. Das sollte dann so aussehen, wenn Du fertig bist:
 
 div(filename). pom.xml
 
@@ -156,27 +155,27 @@ bc(prettify).. <!-- clip -->
 </dependencies>
 <!-- clip -->
 
-p. Die Grundlagen für Dein Projekt sind jetzt fertig! Überspringe den nächsten Abschnitt und gehe direkt zu "Projekt in Eclipse öffnen":#open_project_in_eclipse damit wir endlich Code schreiben können!
+p. Die Grundlagen für Dein Projekt sind jetzt fertig! Überspringe den nächsten Abschnitt und gehe direkt zu "Projekt in Eclipse öffnen":#open_project_in_eclipse, damit wir endlich Code schreiben können!
 
 h4(#create_project_using_forge). Erstelle und passe ein Projekt mit JBoss Forge an
 
-"JBoss Forge":forge_home ist ein Kommando-Zeilen Werkzeug zum Rapid-Application Development in einer auf Standards basierenden Umgebung. Gerne auch als "Maven Archetypes on steroids" bezeichnet.
+"JBoss Forge":forge_home ist ein Kommandozeilenwerkzeug zum Rapid Application Development in einer auf Standards basierenden Umgebung. Gerne auch als "Maven Archetypes on steroids" bezeichnet.
 
-Forge ist schnell installiert und dieser Guide führt Dich durch die Grundlagen. Folge einfach diesen einfachen Schritten um es zu installieren:
+Forge ist schnell installiert und dieser Guide führt Dich durch die Grundlagen. Folge einfach diesen einfachen Schritten, um es zu installieren:
 
 # "Download Forge":forge_download und packe Forge in ein beliebiges Verzeichnis auf Deiner Festplatte aus. Diese nennen wir @$FORGE_HOME@
-Wir gehen davon aus, dass Du die Distribution in ein Verzeichnis mit dem Namen @forge@ in Deinem Home Verzeichnis ausgepackt hast.
+Wir gehen davon aus, dass Du die Distribution in ein Verzeichnis mit dem Namen @forge@ in Deinem Home-Verzeichnis ausgepackt hast.
 
 # Füge @$FORGE_HOME/bin@ zu Deinem Pfad hinzu (Windows, Linux oder Mac OSX)
 
-Auf Unix basierenden Systemen bedeutet dies, dass Du $HOME/.bashrc or $HOME/.profile editieren musst. Eine entsprechende Ergänzung sieht dann beispielsweise so aus:
+Auf Unix-basierenden Systemen bedeutet dies, dass Du $HOME/.bashrc or $HOME/.profile editieren musst. Eine entsprechende Ergänzung sieht dann beispielsweise so aus:
 
 bc(command). $ export FORGE_HOME=$HOME/forge/
 $ export PATH=$PATH:$FORGE_HOME/bin
 
-p(info). %Unter Windows kann dies über die Systemeigenschaften eingestellt werden. Dorthin gelangst Du mit einem Rechts-Klick auf die "Systemsteuerung", dann Klick auf "System Eigenschaften", dort der Tab Reiter "Erweitert". Ein Klick auf "Umgebungsvariablen" ermöglicht das Hinzufügen der beiden Einträge. Es wird empfohlen die Einträge als Nutzer Variablen vorzunehmen. System Variablen ist nur sinnvoll, wenn Forge in einem Verzeichnis installiert ist, welches von allen Systembenutzern gelesen werden kann.%
+p(info). %Unter Windows kann dies über die Systemeigenschaften eingestellt werden. Dorthin gelangst Du mit einem Rechtsklick auf die "Systemsteuerung", dann Klick auf "Systemeigenschaften", dort der Reiter "Erweitert". Ein Klick auf "Umgebungsvariablen" ermöglicht das Hinzufügen der beiden Einträge. Es wird empfohlen die Einträge als Nutzervariablen vorzunehmen. Systemvariablen ist nur sinnvoll, wenn Forge in einem Verzeichnis installiert ist, welches von allen Systembenutzern gelesen werden kann.%
 
-Nachdem Forge installiert (bzw. entpackt) wurde öffne die Kommandozeile und führe das folgende @forge@ Kommando aus:
+Nachdem Forge installiert (bzw. entpackt) wurde, öffne die Kommandozeile und führe das folgende @forge@-Kommando aus:
 
 bc(command).. $ forge
    _____
@@ -188,33 +187,33 @@ bc(command).. $ forge
 
 [no project] ~ $
 
-p. Das war es schon! Forge läuft und es wird Zeit, dass Projekt zu erstellen.
+p. Das war es schon! Forge läuft und es wird Zeit, das Projekt zu erstellen.
 
-Tippe das folgende Kommando innerhalb der Forge shell. Es erzeugt ein leeres Projekt in etwa der Art wie es der Maven Archetype auch getan hat:
+Tippe das folgende Kommando innerhalb der Forge-Shell. Es erzeugt ein leeres Projekt in etwa der Art, wie es der Maven-Archetype auch getan hat:
 
 bc(command). $ project-new --named arquillian-tutorial --topLevelPackage org.arquillian.example
 
-p. Dieses Kommando erzeugt ein Maven basiertes Java Projekt innerhalb eines @arquillian-tutorial@ genannten Verzeichnisses direkt unterhalb des aktuellen Verzeichnisses.
+p. Dieses Kommando erzeugt ein Maven-basiertes Java-Projekt innerhalb eines @arquillian-tutorial@ genannten Verzeichnisses direkt unterhalb des aktuellen Verzeichnisses.
 
 Die Dateistruktur ist dabei wie folgt erzeugt worden:
 
 (Dateibaum)* src/
 ** main/
-*** java/ - Hier kommen alle Java Source Dateien hin (in Java Packages)
+*** java/ - Hier kommen alle Java-Sourcedateien hin (in Java-Packages)
 *** resources/ - Hier kommen alle Konfigurationsdateien der Anwendung hin.
 **** META-INF/
 ***** forge.xml - Eine leere Forge Settings Datei
 ** test/
-*** java/ - Hier kommen alle Java Test Source Dateien hin (in Java Packages)
-*** resources/ - Hier kommen alle Konfigurationsdateien der für die Tests hin, (beispielsweise: arquillian.xml)
-* pom.xml - Die Maven Build Datei, welche Maven sagt, wie das Projekt zu bauen ist.
+*** java/ - Hier kommen alle Test-Java-Source-Dateien hin (in Java-Packages)
+*** resources/ - Hier kommen alle Konfigurationsdateien für die Tests hin (beispielsweise: arquillian.xml)
+* pom.xml - Die Maven-Builddatei, welche Maven sagt, wie das Projekt zu bauen ist.
 
 Forge wechselt automatisch in das erstellte Projektverzeichnis.
 
 bc(command). [arquillian-tutorial] arquillian-tutorial $
 
 
-Nun müssen die Java EE APIs hinzugefügt werden. Das wird mit dem @project add-dependency@ Kommando gemacht:
+Nun müssen die Java-EE-APIs hinzugefügt werden. Das wird mit dem @project-add-dependency@-Kommando gemacht:
 
 bc(command). $ project-add-dependencies org.jboss.spec:jboss-javaee-7.0:1.0.3.Final:pom:provided
 
@@ -285,41 +284,41 @@ bc(prettify).. <?xml version="1.0" encoding="UTF-8"?>
 
 p(info). %Arquillian kann über das Maven Central Repository bezogen werden. Daher ist der Verweis auf das JBoss Public Repository in der pom.xml überflüssig und kann entfernt werden. Behalte aber im Hinterkopf, dass es durchaus abhängige Bibliotheken von JBoss gibt, welche nicht über Maven Central bezogen werden können.%
 
-p(warning). %Wenn Du zu den Anhängern gehörst, welche das Hinzufügen von Repositories in Projekt pom.xml für ein Anti-Pattern halten, dann lies "diese Anweisungen":http://community.jboss.org/wiki/MavenGettingStarted-Users um die Repositories global in der Maven settings.xml Datei einzustellen.%
+p(warning). %Wenn Du zu den Anhängern gehörst, welche das Hinzufügen von Repositories in Projekt pom.xml für ein Anti-Pattern halten, dann lies "diese Anweisungen":http://community.jboss.org/wiki/MavenGettingStarted-Users, um die Repositories global in der Maven-settings.xml-Datei einzustellen.%
 
 p. Die Grundlagen für Dein Projekt sind jetzt fertig! Öffne das Projekt in Eclipse, damit wir endlich Code schreiben können!
 
 h3. Projekt in Eclipse öffnen
 
-Beim Entwickeln eines Java Projektes wirst Du vermutlich eine IDE, beispielsweise Eclipse, verwenden. Daher wurde Arquillian auch IDE-freundlich konzipiert. Das bedeutet, dass Arquillian Tests aus der IDE ohne besondere Änderungen ausführbar sind. Darum starten wir auch gleich mit der IDE:
+Beim Entwickeln eines Java-Projektes wirst Du vermutlich eine IDE, beispielsweise Eclipse, verwenden. Daher wurde Arquillian auch IDE-freundlich konzipiert. Das bedeutet, dass Arquillian Tests aus der IDE ohne besondere Änderungen ausführbar sind. Darum starten wir auch gleich mit der IDE:
 
-Starte Eclipse. Da dies ein Maven basiertes Projekt ist, benötigst Du die "Maven Integration for Eclipse":m2e_home auch m2e Plugin genannt um das Projekt zu öffnen. Hast Du diese nicht bereits installiert, kannst Du auch einfach die "JBoss Tools":tools_home installieren. Sie enthalten bereits die Maven Integration. Die folgenden Schritte beschreiben die Installation direkt über den Eclipse Marketplace (eine Art AppStore für Eclipse Plugins).
+Starte Eclipse. Da dies ein Maven-basiertes Projekt ist, benötigst Du die "Maven Integration for Eclipse":m2e_home, auch m2e-Plugin genannt, um das Projekt zu öffnen. Hast Du diese nicht bereits installiert, kannst Du auch einfach die "JBoss Tools":tools_home installieren. Sie enthalten bereits die Maven-Integration. Die folgenden Schritte beschreiben die Installation direkt über den Eclipse Marketplace (eine Art AppStore für Eclipse-Plugins).
 
 # Wähle das Menü @Hilfe > Eclipse Marketplace...@ vom Hauptmenü
 # Tippe "jboss tools" in das Eingabefeld (ohne Anführungszeichen) und drücke @<ENTER>@
-# Klicke auf den "Installieren" Knopf neben dem Ergebnis "JBoss Tools (Indigo)"
+# Klicke auf den "Installieren"-Knopf neben dem Ergebnis "JBoss Tools (Indigo)"
 # Beende den Install Wizard und starte Eclipse neu, wenn Du dazu aufgefordert wirst.
 
-Bei den JBoss Tools handelt es sich um ein leichtgewichtiges Plugin, welches ein umfangreiches Set an Werkzeugen zur Entwicklung von Java EE Anwendungen, inklusive CDI Unterstützung bereitstellt. Um produktiv arbeiten zu können, empfehlen wir es daher, dieses Plugin zu verwenden.
+Bei den JBoss Tools handelt es sich um ein leichtgewichtiges Plugin, welches ein umfangreiches Set an Werkzeugen zur Entwicklung von Java-EE-Anwendungen inklusive CDI-Unterstützung bereitstellt. Um produktiv arbeiten zu können, empfehlen wir es daher, dieses Plugin zu verwenden.
 
-Wenn du darauf allerdings verzichten möchtest und lieber nur die Maven Integration ohne Plugins verwenden möchtest, folge diesen einfachen Schritten:
+Wenn du darauf allerdings verzichten möchtest und lieber nur die Maven-Integration ohne Plugins verwenden möchtest, folge diesen einfachen Schritten:
 
-# Select @Help > Eclipse Marketplace...@ from the main menu
+# Wähle das Menü @Hilfe > Eclipse Marketplace...@ vom Hauptmenü
 # Tippe "maven" in in das Eingabefeld (ohne Anführungszeichen) und drücke @<ENTER>@
-# Klicke auf den "Installieren" Knopf neben dem Ergebnis "Maven Integration for Eclipse"
-# Beende den Install Wizard und starte Eclipse neu wenn Du dazu aufgefordert wirst.
+# Klicke auf den "Installieren"-Knopf neben dem Ergebnis "Maven Integration for Eclipse"
+# Beende den Install Wizard und starte Eclipse neu wenn Du dazu aufgefordert wirst
 # Wiederhole die Schritte für die "Maven Integration für Eclipse WTP"
 
-Ist das Maven Plugin installiert, kann man mit einfachen Schritten das Projekt direkt öffnen:
+Ist das Maven-Plugin installiert, kann man mit einfachen Schritten das Projekt direkt öffnen:
 
 # Wähle @Datei > Import...@ vom Hauptmenü
 # Tippe "existing maven" in in das Eingabefeld
-# Wähle die Option "Existing Maven Projects", dann klicke auf den Weiter Knopf
+# Wähle die Option "Existing Maven Projects", dann klicke auf den Weiter-Knopf
 # Klicke den "Durchsuchen ...." Knopf
-# Navigiere zum Projekt Verzeichnis in Deinem Dateisystem, dann Klicke den OK Knopf.
+# Navigiere zum Projektverzeichnis in Deinem Dateisystem, dann Klicke den OK-Knopf.
 # Klicke auf "Fertig" um das Projekt zu öffnen
 
-Eclipse erkennt dann das Maven Projekt und öffnet es in der Projekt Navigator View. Wenn Du das Projekt aufklappst, sollte es folgendermaßen aussehen:
+Eclipse erkennt dann das Maven-Projekt und öffnet es in der Project Navigator View. Wenn Du das Projekt aufklappst, sollte es folgendermaßen aussehen:
 
 !/images/guides/arquillian_tutorial_eclipse_project.png!
 
@@ -327,9 +326,9 @@ Jetzt kann es aber wirklich losgehen!
 
 h3. Eine Komponente erstellen
 
-Um einen Arquillian Test schreiben zu können, benötigen wir erst einmal eine Komponente, welche es zu testen gibt. Wir fangen mit einer einfachen Komponente an, damit Du lernen kannst, wie ein einfach Arquillian Test ausgeführt wird. In den nächsten Schritten geht es zu deutlich komplexeren Szenarien.
+Um einen Arquillian-Test schreiben zu können, benötigen wir erst einmal eine Komponente, welche es zu testen gibt. Wir fangen mit einer einfachen Komponente an, damit Du lernen kannst, wie ein einfach Arquillian-Test ausgeführt wird. In den nächsten Schritten geht es zu deutlich komplexeren Szenarien.
 
-Erstelle mithilfe Deiner IDE eine neue Java Klasse mit dem Namen @Greeter@ im @org.arquillian.example@ Package. Ersetze den Inhalt mit dem folgenden Code:
+Erstelle mithilfe Deiner IDE eine neue Java-Klasse mit dem Namen @Greeter@ im @org.arquillian.example@-Package. Ersetze den Inhalt mit dem folgenden Code:
 
 div(filename). src/main/java/org/arquillian/example/Greeter.java
 
@@ -351,13 +350,13 @@ public class Greeter {
 }
 
 
-p. Im Test wollen wir sicherstellen, dass diese Klasse sich richtig verhält, wenn sie als CDI(Contexts and Dependency Injection) Bean aufgerufen wird. Natürlich könnten wir jetzt auch einen einfachen Unit-Test schreiben, aber lass uns einfach annehmen, dass diese Bean weitere Enterprise Services wie beispielsweise Dependency Injection und Messaging nutzt und in einem Container ausgeführt werden muss. (Und außerdem hat es so Raum zu wachsen ~;))
+p. Im Test wollen wir sicherstellen, dass diese Klasse sich richtig verhält, wenn sie als CDI (Contexts and Dependency Injection) Bean aufgerufen wird. Natürlich könnten wir jetzt auch einen einfachen Unit-Test schreiben, aber lass uns einfach annehmen, dass diese Bean weitere Enterprise Services wie beispielsweise Dependency Injection und Messaging nutzt und in einem Container ausgeführt werden muss. (Und außerdem hat es so Raum zu wachsen ~;))
 
-Um diese Klasse als CDI Bean zu benutzen injizieren wir sie mithilfe der @@Inject@ Annotation in den Test. Das schreit doch geradezu nach einem Arquillian Test! Nun wird es also Zeit, die Arquillian API zum Projekt hinzu zu fügen!
+Um diese Klasse als CDI Bean zu benutzen, injizieren wir sie mithilfe der @@Inject@-Annotation in den Test. Das schreit doch geradezu nach einem Arquillian-Test! Nun wird es also Zeit, die Arquillian-API zum Projekt hinzuzufügen!
 
-h3. Arquillian APIs hinzufügen
+h3. Arquillia-APIs hinzufügen
 
-Öffne die @pom.xml@ ein weiteres Mal im Editor. (Erinnerung: Sie liegt im root Verzeichnis Deines Projektes). Jetzt muss Maven wissen, welche Version der Abhängigkeiten es verwenden soll. Dazu wird das folgende XML Fragment direkt oberhalb des @<build>@ Elements eingefügt um den sogenannten BOM(Bill of Materials) bzw. die Versions-Matrix für alle transitiven Abhängigkeiten von Arquillian zu importieren.
+Öffne die @pom.xml@ ein weiteres Mal im Editor. (Erinnerung: Sie liegt im Rootverzeichnis Deines Projektes). Jetzt muss Maven wissen, welche Version der Abhängigkeiten es verwenden soll. Dazu wird das folgende XML-Fragment direkt oberhalb des @<build>@-Elements eingefügt, um den sogenannten BOM (Bill of Materials) bzw. die Versionsmatrix für alle transitiven Abhängigkeiten von Arquillian zu importieren.
 
 div(filename). pom.xml
 
@@ -375,7 +374,7 @@ bc(prettify).. <!-- clip -->
 </dependencyManagement>
 <!-- clip -->
 
-p. Nun muss die Arquillian JUnit Integration als Abhängigkeit ergänzt werden. Dazu gehört dieses XML Fragment unter das letzte geschlossene @<dependency>@ element:
+p. Nun muss die Arquillian-JUnit-Integration als Abhängigkeit ergänzt werden. Dazu gehört dieses XML-Fragment unter das letzte geschlossene @<dependency>@-Element:
 
 div(filename). pom.xml
 
@@ -387,21 +386,21 @@ bc(prettify).. <!-- clip -->
 </dependency>
 <!-- clip -->
 
-p. Die Arquillian JUnit Integration fügt auch die Arquillian und die ShrinkWrap APIs zum Test Classpath hinzu. Alle diese Bibliotheken werden benötigt, um einen Arquillian Test schreiben und kompilieren zu können.
+p. Die Arquillian-JUnit-Integration fügt auch die Arquillian- und die ShrinkWrap-APIs zum Test-Classpath hinzu. Alle diese Bibliotheken werden benötigt, um einen Arquillian-Test schreiben und kompilieren zu können.
 
-p(info). %Um statt JUnit TestNG zu verwenden, muss die Arquillian JUnit Integration mit der Arquillian TestNG Integration ersetzt werden.%
+p(info). %Um statt JUnit TestNG zu verwenden, muss die Arquillian-JUnit-Integration mit der Arquillian-TestNG-Integration ersetzt werden.%
 
-p. Wenn Du Probleme mit dem bisher erstellen pom.xml hast, dann kannst Du eine komplette Version "von diesem gist":https://gist.github.com/1263892 herunterladen.
+p. Wenn Du Probleme mit dem bisher erstellten pom.xml hast, dann kannst Du eine komplette Version "von diesem gist":https://gist.github.com/1263892 herunterladen.
 
-*Jetzt ist alles vorbereitet um Deinen ersten Arquillian Test zu schreiben!*
+*Jetzt ist alles vorbereitet, um Deinen ersten Arquillian-Test zu schreiben!*
 
-h3. Einen Arquillian Test schreiben
+h3. Einen Arquillian-Test schreiben
 
-Ein Arquillian Test sieht erst mal so aus wie ein herkömmlicher Unit Test. Allerdings mit etwas mehr Flair. Zurück zu Deiner IDE:
+Ein Arquillian-Test sieht erst mal so aus wie ein herkömmlicher Unittest. Allerdings mit etwas mehr Flair. Zurück zu Deiner IDE:
 
-p(warning). %Wenn Du die Meldung "Project configuration is out of date with pom.xml" erhälst, dann klicke rechts auf das Projekt und wähle Project > Maven > Update Project Configuration um das Projekt neu zu synchronisieren.%
+p(warning). %Wenn Du die Meldung "Project configuration is out of date with pom.xml" erhälst, dann klicke rechts auf das Projekt und wähle Project > Maven > Update Project Configuration, um das Projekt neu zu synchronisieren.%
 
-Starten wir mit dem Erstellen eines neuen JUnit Testfalls mit dem Namen @GreeterTest@ im Verzeichnis src/test/java unterhalt des @org.arquillian.example@ Packages. Du wirst die typischen setUp() und tearDown() Methoden nicht benötigen, da Arquillian das meiste der harten Arbeit für Dich übernimmt. Das hier haben wir bisher:
+Starten wir mit dem Erstellen eines neuen JUnit-Testfalls mit dem Namen @GreeterTest@ im Verzeichnis src/test/java unterhalb des @org.arquillian.example@-Packages. Du wirst die typischen setUp()- und tearDown()- Methoden nicht benötigen, da Arquillian das meiste der harten Arbeit für Dich übernimmt. Das hier haben wir bisher:
 
 div(filename). src/test/java/org/arquillian/example/GreeterTest.java
 
@@ -417,21 +416,21 @@ public class GreeterTest {
     }
 }
 
-p. Nun zum Flair. Ein Arquillian Testfall muss drei Dinge beinhalten:
+p. Nun zum Flair. Ein Arquillian-Testfall muss drei Dinge beinhalten:
 
-# Die @@RunWith(Arquillian.class)@ Annotation an der Klasse
-# Eine statische Methode annotiert mit @@Deployment@, welche ein ShrinkWrap Archive zurückgibt
+# Die @@RunWith(Arquillian.class)@-Annotation an der Klasse
+# Eine statische Methode annotiert mit @@Deployment@, welche ein ShrinkWrap-Archiv zurückgibt
 # Und mindestens eine Methode, welche mit @@Test@ annotiert ist
 
-Die @@RunWith@ Annotation sagt JUnit, dass es den Arquillian Test Controller verwenden soll. Arquillian schaut dann nach der statischen Methode mit der @@Deployment@ Annotation und empfängt das Test Archiv (auch micro-deployment genannt). Dann passiert ein gewisses Maß an Magie und jede mit @@Test@ annotierte Methode wird innerhalb der Container Umgebung ausgeführt.
+Die @@RunWith@-Annotation sagt JUnit, dass es den Arquillian-Testcontroller verwenden soll. Arquillian schaut dann nach der statischen Methode mit der @@Deployment@-Annotation und empfängt das Testarchiv (auch micro-deployment genannt). Dann passiert ein gewisses Maß an Magie und jede mit @@Test@ annotierte Methode wird innerhalb der Containerumgebung ausgeführt.
 
-h4. Was genau ist ein Test Archiv?
+h4. Was genau ist ein Testarchiv?
 
-Der Zweck eines Test Archivs ist die Isolation von Klassen und Ressourcen welche für den Test benötigt werden von dem Rest des Classpath. Im Gegensatz zu einem normalen Unit Testfall, bindet sich Arquillian nicht einfach in den kompletten Classpath ein. Im Gegenteil, Du fügst lediglich die Teile hinzu, welche auch vom Test benötigt werden (Das kann der komplette Classpath sein, aber das entscheidest nur Du). Das Archiv wird per "ShrinkWrap":shrinkwrap_home definiert. Das ist eine Java API zur Erzeugung von Archiven (beispielsweise jar, war, ear). Die micro-deployment Strategie erlaubt es Dir, Dich auf die eigentlichen Testklassen zu fokussieren. Im Ergebnis führt das zu sehr schlanken Testklassen.
+Der Zweck eines Testarchivs ist die Isolation von Klassen und Ressourcen, welche für den Test benötigt werden, von dem Rest des Classpath. Im Gegensatz zu einem normalen Unittestfall bindet sich Arquillian nicht einfach in den kompletten Classpath ein. Im Gegenteil, Du fügst lediglich die Teile hinzu, welche auch vom Test benötigt werden (das kann der komplette Classpath sein, aber das entscheidest nur Du). Das Archiv wird per "ShrinkWrap":shrinkwrap_home definiert. Das ist eine Java-API zur Erzeugung von Archiven (beispielsweise jar, war, ear). Die Micro-deployment-Strategie erlaubt es Dir, Dich auf die eigentlichen Testklassen zu fokussieren. Im Ergebnis führt das zu sehr schlanken Testklassen.
 
-p(info). %ShrinkWrap unterstützt auch das Auffinden von Artefakten (Bibliotheken) und das programmatische Erstellen von Konfigurationsdateien, welche ebenfalls im Test Archiv verpackt werden können. Für eine gründlichere Einführung in ShrinkWrap empfiehlt sich der "ShrinkWrap introduction":/guides/shrinkwrap_introduction guide.%
+p(info). %ShrinkWrap unterstützt auch das Auffinden von Artefakten (Bibliotheken) und das programmatische Erstellen von Konfigurationsdateien, welche ebenfalls im Testarchiv verpackt werden können. Für eine gründlichere Einführung in ShrinkWrap empfiehlt sich der "ShrinkWrap introduction":/guides/shrinkwrap_introduction guide.%
 
-Fügen wir das Arquillian Flair dem Test hinzu:
+Fügen wir das Arquillian-Flair dem Test hinzu:
 
 div(filename). src/test/java/org/arquillian/example/GreeterTest.java
 
@@ -462,9 +461,9 @@ public class GreeterTest {
     }
 }
 
-p. Mithilfe von ShrinkWrap haben wir ein Java Archiv (jar) als Deployment Artefakt definiert. Es enthält die zu testende @Greeter@ Klasse und eine leere beans.xml Datei welche als Ressource im META-INF Verzeichnis liegen soll. Mit diesem Trick aktivieren wir die CDI Funktionen für dieses Archiv.
+p. Mithilfe von ShrinkWrap haben wir ein Java-Archiv (jar) als Deployment-Artefakt definiert. Es enthält die zu testende @Greeter@-Klasse und eine leere beans.xml-Datei, welche als Ressource im META-INF-Verzeichnis liegen soll. Mit diesem Trick aktivieren wir die CDI-Funktionen für dieses Archiv.
 
-Alles was nun noch zu tun bleibt ist, die @Greeter@ Instanz in ein Feld direkt oberhalb der Test Methode zu injizieren und die bisher nicht implementierte Test Methode mit einem Assert auf das Verhalten des Beans auszuprogrammieren.
+Alles was nun noch zu tun bleibt, ist, die @Greeter@-Instanz in ein Feld direkt oberhalb der Testmethode zu injizieren und die bisher nicht implementierte Testmethode mit einem Assert auf das Verhalten des Beans auszuprogrammieren.
 Um Dir ein warmes und wohliges Gefühl zu vermitteln, werden wir auch die Begrüßung auf der Konsole ausgeben.
 
 div(filename). src/test/java/org/arquillian/example/GreeterTest.java
@@ -520,19 +519,19 @@ public class GreeterTest {
     }
 }
 
-p. Glückwunsch! Damit hast Du gerade Deinen ersten Arquillian Test geschrieben!
+p. Glückwunsch! Damit hast Du gerade Deinen ersten Arquillian-Test geschrieben!
 
-Ahhh. Aber Du wunderst Dich vielleicht darüber, wie Du Ihn ausführen sollst? ~:S Wenn Du denkst, "Einfach wie einen JUnit Test", liegst Du genau richtig! Dennoch müssen wir zuerst einen Container Adapter zum Classpath hinzufügen.
+Ahhh. Aber Du wunderst Dich vielleicht darüber, wie Du ihn ausführen sollst? ~:S Wenn Du denkst, "Einfach wie einen JUnit-Test", liegst Du genau richtig! Dennoch müssen wir zuerst einen Container-Adapter zum Classpath hinzufügen.
 
-h3. Einen Container Adapter hinzufügen
+h3. Einen Container-Adapter hinzufügen
 
-Wir haben eine Menge über Tests innerhalb irgendeines Containers gesprochen. Bisher aber nicht gesagt, welchen Container wir verwenden. Das liegt daran, dass es eine Laufzeitentscheidung ist.
+Wir haben eine Menge über Tests innerhalb irgendeines Containers gesprochen, bisher aber nicht gesagt, welchen Container wir verwenden. Das liegt daran, dass es eine Laufzeitentscheidung ist.
 
-Arquillian wählt den Ziel-Container auf der Grundlage des im Classpath verfügbaren Container Adapters aus. Das bedeutet, dass wir weitere Bibliotheken zum Projekt hinzufügen werden.
+Arquillian wählt den Ziel-Container auf der Grundlage des im Classpath verfügbaren Container-Adapters aus. Das bedeutet, dass wir weitere Bibliotheken zum Projekt hinzufügen werden.
 
-Ein Arquillian Test kann in allen Containern ausgeführt werden, welche mit dem Programmiermodell des Tests kompatibel sind und Arquillian einen entsprechenden Container Adapter bereitstellt. Der bisherige Test verwendet das CDI Programmiermodell; wir benötigen also einen Container, welcher dieses unterstützt. Wir wollen einen schnellen Roundtrip und starten daher mit dem Weld EE embedded Container.
+Ein Arquillian-Test kann in allen Containern ausgeführt werden, welche mit dem Programmiermodell des Tests kompatibel sind und für die Arquillian einen entsprechenden Container-Adapter bereitstellt. Der bisherige Test verwendet das CDI-Programmiermodell; wir benötigen also einen Container, welcher dieses unterstützt. Wir wollen einen schnellen Roundtrip und starten daher mit dem Weld EE embedded Container.
 
-Öffne wieder die Projektkonfiguration @pom.xml@ und füge die folgende Gruppe von Abhängigkeiten unterhalb des letzten, schließenden @<dependency>@ Elements hinzu:
+Öffne wieder die Projektkonfiguration @pom.xml@ und füge die folgende Gruppe von Abhängigkeiten unterhalb des letzten, schließenden @<dependency>@-Elements hinzu:
 
 div(filename). pom.xml
 
@@ -557,21 +556,21 @@ bc(prettify).. <!-- clip -->
 </dependency>
 <!-- clip -->
 
-p. Zusammenfassend benötigst Du diese drei Bibliotheken um Arquillian mit JUnit zu verwenden:
+p. Zusammenfassend benötigst Du diese drei Bibliotheken, um Arquillian mit JUnit zu verwenden:
 
-# Die Arquillian JUnit Integration
-# Einen Arquillian Container Adapter für den gewünschten Ziel-Container
-# Die Container Laufzeit (für einen embedded container) oder einen Container Client (für einen remote container)
+# Die Arquillian-JUnit-Integration
+# Einen Arquillian-Container-Adapter für den gewünschten Zielcontainer
+# Die Container-Laufzeit (für einen embedded container) oder einen Container-Client (für einen remote container)
 
-Wir verwenden einen sogenannten "embedded Container" in diesem Beispiel. Das bedeutet wir benötigen die Container Laufzeitumgebung: Also Weld.
+Wir verwenden einen sogenannten "embedded container" in diesem Beispiel. Das bedeutet, wir benötigen die Container-Laufzeitumgebung: Also Weld.
 
 Aber zurück zum Test.
 
-h3. Den Arquillian Test ausführen
+h3. Den Arquillian-Test ausführen
 
-Sind alle notwendigen Abhängigkeiten bzw. Bibliotheken dem Classpath hinzugefügt, kann der Arquillian Test genau wie ein Unit test ausgeführt werden. Egal ob durch die IDE oder das build script oder andere Build Plugins. Wir führen den Beispiel Test in Eclipse aus.
+Sind alle notwendigen Abhängigkeiten bzw. Bibliotheken dem Classpath hinzugefügt, kann der Arquillian-Test genau wie ein Unittest ausgeführt werden; egal ob durch die IDE oder das Buildscript oder andere Build-Plugins. Wir führen den Beispieltest in Eclipse aus.
 
-Im IDE Fenster klicke mit der rechten Maustaste auf die @GreeterTest.java@ Datei im Eclipse Package Explorer (oder im Editor) und wähle "Run As > JUnit Test" aus dem Kontextmenü.
+Im IDE-Fenster klicke mit der rechten Maustaste auf die @GreeterTest.java@-Datei im Eclipse Package Explorer (oder im Editor) und wähle "Run As > JUnit Test" aus dem Kontextmenü.
 
 !/images/guides/arquillian_tutorial_run_junit_test.png!
 
@@ -600,11 +599,11 @@ Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.907 sec
 
 *Herzlichen Glückwunsch!* Du hast Dir grade Deine erste *(greenbar)green bar* mit Arquillian verdient!
 
-h3. Genauer Hingeschaut!
+h3. Genauer hingeschaut!
 
-Wie kannst Du wissen, dass CDI wirklich funktioniert? Nach allem was Du weißt hat Arquillian eine neue Instanz der @Greeter@ Klasse erzeugt und in den Test ohne weitere Beteiligung von CDI injiziert. Lass uns beweisen, dass sie wirklich da ist.
+Wie kannst Du wissen, dass CDI wirklich funktioniert? Nach allem, was Du weißt, hat Arquillian eine neue Instanz der @Greeter@-Klasse erzeugt und in den Test ohne weitere Beteiligung von CDI injiziert. Lass uns beweisen, dass sie wirklich da ist.
 
-Erstelle eine neue CDI Bean mit dem Namen @PhraseBuilder@ im @org.arquillian.example@ Package. Diese soll Sätze aus Vorlagen erstellen können.
+Erstelle eine neue CDI-Bean mit dem Namen @PhraseBuilder@ im @org.arquillian.example@-Package. Diese soll Sätze aus Vorlagen erstellen können.
 
 div(filename). src/main/java/org/arquillian/example/PhraseBuilder.java
 
@@ -629,7 +628,7 @@ public class PhraseBuilder {
     }
 }
 
-p. Öffne nun die @Greeter@ Klasse und erstelle einen neuen Constructor welcher eine @PhraseBuilder@ Instanz über Constructor Injection erzeugt. Dann delegiere die Erzeugung der Begrüßung an die injizierte Bean.
+p. Öffne nun die @Greeter@-Klasse und erstelle einen neuen Konstruktor, welcher eine @PhraseBuilder@-Instanz über Constructor Injection erzeugt. Dann delegiere die Erzeugung der Begrüßung an die injizierte Bean.
 
 div(filename). src/main/java/org/arquillian/example/Greeter.java
 
@@ -656,9 +655,9 @@ public class Greeter {
     }
 }
 
-p. Damit der Test wirklich funktioniert, muss jetzt also eine Instanz der Klasse @PhraseBuilder@ erstellt werden, seine @@PostConstruct@ Methode ausgeführt und in den Constructor der @Greeter@ Instanz injiziert werden, sobald eine @Greeter@ Instanz erzeugt wird. Wir können sicher sein, dass CDI am Werk ist, wenn all dies zusammenspielt.
+p. Damit der Test wirklich funktioniert, muss jetzt also eine Instanz der Klasse @PhraseBuilder@ erstellt werden, seine @@PostConstruct@ Methode ausgeführt und in den Constructor der @Greeter@ Instanz injiziert werden, sobald eine @Greeter@-Instanz erzeugt wird. Wir können sicher sein, dass CDI am Werk ist, wenn all dies zusammenspielt.
 
-p. Ein letzter Schritt: Da wir eine neue Klasse erstellt haben, müssen wir zuerst sicherstellen, dass diese in der @@Deployment@ Methode vom Test dem Archiv hinzugefügt wird. Dazu verändern wir einfach die folgende Zeile von:
+p. Ein letzter Schritt: Da wir eine neue Klasse erstellt haben, müssen wir zuerst sicherstellen, dass diese in der @@Deployment@-Methode des Tests dem Archiv hinzugefügt wird. Dazu verändern wir einfach die folgende Zeile von:
 
 bc(prettify).. .addClass(Greeter.class)
 
@@ -668,31 +667,31 @@ bc(prettify).. .addClasses(Greeter.class, PhraseBuilder.class)
 
 p. Lass den Test erneut ablaufen. Du solltest erneut eine *(greenbar)green bar*! sehen! Fühlt sich gut an, nicht wahr?
 
-h3. Den Test Debuggen
+h3. Den Test debuggen
 
-Das wird ein kurzes Kapitel. Warum? Weil Arquillian Tests so unkompliziert sind, dass Du sie genauso wie alle anderen Unit Tests debuggen kannst. Füge einfach irgendwo einen Breakpoint hinzu (entweder im Test-Code oder im Anwendungs-Code) und klicke mit der rechten Maustaste oder im Editor auf den Test und wähle "Debug As > JUnit Test". Jetzt debuggst Du im Container!
+Das wird ein kurzes Kapitel. Warum? Weil Arquillian-Tests so unkompliziert sind, dass Du sie genauso wie alle anderen Unittests debuggen kannst. Füge einfach irgendwo einen Breakpoint hinzu (entweder im Test-Code oder im Anwendungs-Code) und klicke mit der rechten Maustaste oder im Editor auf den Test und wähle "Debug As > JUnit Test". Jetzt debuggst Du im Container!
 
 !/images/guides/arquillian_tutorial_debugging_test.png!
 
-p(warning). %Wenn Du einen Remote Container verwendest funktioniert das so nicht. Stattdessen muss der Container im Debug Mode gestartet  und der Debugger angehängt werden. Der Test läuft dann nämlich in einer anderen JVM als der eigentliche Code.%
+p(warning). %Wenn Du einen Remote Container verwendest, funktioniert das so nicht. Stattdessen muss der Container im Debug Mode gestartet und der Debugger angehängt werden. Der Test läuft dann nämlich in einer anderen JVM als der eigentliche Code.%
 
-Du hast grade erlebt, dass Arquillian das ideale Werkzeug für das Testen von CDI Anwendungen ist. Es kümmert sich um das Laden der CDI Umgebung und injiziert die Beans direkt in den Testfall. Das Beste daran ist, dass bei der Verwendung des embedded CDI Containers die Tests genauso schnell ablaufen als bei einem einfachen Unit Test. Wenn das alles ist, was Du benötigst kannst Du den Guide jetzt zu machen und anfangen Tests zu erstellen.
+Du hast grade erlebt, dass Arquillian das ideale Werkzeug für das Testen von CDI-Anwendungen ist. Es kümmert sich um das Laden der CDI-Umgebung und injiziert die Beans direkt in den Testfall. Das Beste daran ist, dass bei der Verwendung des Embedded-CDI-Containers die Tests genauso schnell ablaufen wie bei einem einfachen Unittest. Wenn das alles ist, was Du benötigst, kannst Du den Guide jetzt zumachen und anfangen Tests zu erstellen.
 
 *Aber!* Erzählt uns der Embedded Container die gesamte Geschichte? Wird die Komponente funktionieren, wenn diese in einem echten Container ausgeführt wird?
 
-Einer der Vorteile von Arquillian ist, dass der gleiche Test in verschiedenen kompatiblen Containern ausgeführt werden kann. Egal ob Embedded oder Remote. Wenn Du daran denkst, mehrere Container zu verwenden, lies einfach weiter.
+Einer der Vorteile von Arquillian ist, dass der gleiche Test in verschiedenen kompatiblen Containern ausgeführt werden kann, egal ob Embedded oder Remote. Wenn Du daran denkst, mehrere Container zu verwenden, lies einfach weiter.
 
 h3. Weitere Container hinzufügen
 
-Wie Du weißt, wählt Arquillian den Container auf Grund des verfügbaren Adapters im Classpath. Um zu einem anderen Container zu wechseln, wechsele einfach den Container Adapter vor dem Ausführen der Tests.
+Wie Du weißt, wählt Arquillian den Container auf Grund des verfügbaren Adapters im Classpath. Um zu einem anderen Container zu wechseln, wechsele einfach den Container-Adapter vor dem Ausführen der Tests.
 
-p(important). %Zu einer bestimmten Zeit darf immer nur ein Container Adapter im Classpath sein!%
+p(important). %Zu einer bestimmten Zeit darf immer nur ein Container-Adapter im Classpath sein!%
 
 Ein Weg die Bibliotheken (Adapter) im Classpath zu wechseln ist es, die Abhängigkeiten in der @pom.xml@ jedes Mal manuell zu ändern. Aber es gibt einen viel besseren Weg.
 
-Wir können die sogenannten Maven Profile verwenden um die Abhängigkeiten in Gruppen zu verteilen. Eine Gruppe/Profil für jeden Container Adapter und die zugehörigen, weiteren Abhängigkeiten. Zur Test Durchführung muss dann lediglich die richtige Gruppe bzw. das richtige Profil per Kommandozeilen Parameter (-P) oder die Voreinstellung in der IDE gewechselt werden.
+Wir können die sogenannten Maven-Profile verwenden, um die Abhängigkeiten in Gruppen zu verteilen: Eine Gruppe/Profil für jeden Container-Adapter und die zugehörigen, weiteren Abhängigkeiten. Zur Testdurchführung muss dann lediglich die richtige Gruppe bzw. das richtige Profil per Kommandozeilenparameter (-P) oder per Voreinstellung in der IDE gewechselt werden.
 
-Öffne die @pom.xml@ Datei und erstelle ein neues Maven Profil für den Weld EE Embedded Container durch das Einfügen der folgenden Zeilen direkt unterhalb des schließenden  @<dependencies>@ Element.
+Öffne die @pom.xml@-Datei und erstelle ein neues Maven-Profil für den Weld-EE-Embedded-Container durch das Einfügen der folgenden Zeilen direkt unterhalb des schließenden @<dependencies>@-Element.
 
 div(filename). pom.xml
 
@@ -731,7 +730,7 @@ bc(prettify).. <!-- clip -->
 </profiles>
 <!-- clip -->
 
-p. Als nächstes *entfernst* Du die @jboss-javaee-7.0@ und die Weld EE Container Adapter Abhängigkeiten aus der Hauptsektion der  @<dependencies>@. Das sollte dann so aussehen, wenn Du fertig bist:
+p. Als nächstes *entfernst* Du die @jboss-javaee-7.0@- und die Weld-EE Container-Adapter-Abhängigkeiten aus der Hauptsektion der  @<dependencies>@. Das sollte dann so aussehen, wenn Du fertig bist:
 
 div(filename). pom.xml
 
@@ -783,9 +782,9 @@ bc(prettify).. <!-- clip -->
 </profiles>
 <!-- clip -->
 
-p(info). %Die Java EE API Abhängigkeit ist ebenfalls in das Container Adapter Profil gewandert, da manche Container wie beispielsweise der Embedded GlassFish diese bereits mitbringen. Beide im Classpath zu haben würde zu Problemen führen. Darum dieser Tanz mit dem Classpath.%
+p(info). %Die Java-EE-API-Abhängigkeit ist ebenfalls in das Container-Adapter-Profil gewandert, da manche Container wie beispielsweise der Embedded GlassFish diese bereits mitbringen. Beide im Classpath zu haben würde zu Problemen führen. Darum dieser Tanz mit dem Classpath.%
 
-Jetzt fügen wir zwei weitere Profile in die @pom.xml@ Datei innerhalb des @<profiles>@ Elements ein. Zuerst für den "Embedded GlassFish":http://embedded-glassfish.java.net:
+Jetzt fügen wir zwei weitere Profile in die @pom.xml@-Datei innerhalb des @<profiles>@-Elements ein. Zuerst für den "Embedded GlassFish":http://embedded-glassfish.java.net:
 
 div(filename). pom.xml
 
@@ -840,57 +839,57 @@ p. Wenn du Probleme mit der pom.xml Datei hast, kannst Du die bisher erstelle di
 
 h3. Test mit mehreren Containern
 
-Aktualisierst Du das Projekt jetzt in Eclipse wirst Du feststellen, dass es nicht mehr gebaut wird. Das liegt daran, dass Du der IDE erst noch sagen musst, welches Maven Profil sie verwenden soll. Also aktivieren wir mal das Weld EE embedded Profil um den Ausgangszustand wiederherzustellen.
+Aktualisierst Du das Projekt jetzt in Eclipse  wirst Du feststellen, dass es nicht mehr gebaut wird. Das liegt daran, dass Du der IDE erst noch sagen musst, welches Maven-Profil sie verwenden soll. Also aktivieren wir mal das Weld-EE-embedded-Profil, um den Ausgangszustand wiederherzustellen.
 
-In Eclipse gibt es zwei Wege um Maven Profile zu aktivieren:
+In Eclipse gibt es zwei Wege, um Maven-Profile zu aktivieren:
 
-# Die Manuelle Konfiguration (Standard Ansatz)
+# Die manuelle Konfiguration (Standardansatz)
 # oder der Maven Profile Selector (durch die JBoss Tools bereitgestellt)
 
-h4. Aktives Maven Profil setzen: Manuelle Konfiguration
+h4. Aktives Maven-Profil setzen: Manuelle Konfiguration
 
-Um das aktive Maven Profil zu setzen, folge diesen Schritten:
+Um das aktive Maven-Profil zu setzen, folge diesen Schritten:
 
 # Rechts-Klick auf das Projekt und Auswahl von "Eigenschaften"
-# Wähle den Maven Eigenschaften Reiter
-# Gib die Profil ID in das Aktive Maven Profiles Feld ein (beispielsweise @arquillian-weld-ee-embedded@)
-# Klicke auf den OK Knopf und akzeptiere die Projektänderungen
+# Wähle den Maven-Eigenschaften-Reiter
+# Gib die Profil-ID in das Aktive-Maven-Profiles-Feld ein (beispielsweise @arquillian-weld-ee-embedded@)
+# Klicke auf den OK-Knopf und akzeptiere die Projektänderungen
 
-Hier ist ein Screenshot des Maven Eigenschaften Dialogs, welcher die aktivierten Profile anzeigt:
+Hier ist ein Screenshot des Maven-Eigenschaften-Dialogs, welcher die aktivierten Profile anzeigt:
 
 !/images/guides/arquillian_tutorial_maven_properties.png!
 
 h4. Aktives Maven Profil setzen: Maven Profile Selector
 
-Wenn Du die JBoss Tools installiert hast, wird das Auswählen des aktiven Maven Profils noch einfacher:
+Wenn Du die JBoss Tools installiert hast, wird das Auswählen des aktiven Maven-Profils noch einfacher:
 
 # Rechts-Klick auf das Projekt und Auswahl von "Maven > Select Active Profiles..." (Alternativ kann dies auch per Ctrl+Shift+P oder dem Knopf aus der Toolbar erfolgen)
-# Wähle die Box neben dem Profil welches Du aktivieren willst an. (beispielsweise @arquillian-weld-ee-embedded@)
-# Klicke auf den OK Knopf.
+# Wähle die Box neben dem Profil, welches Du aktivieren willst, an (beispielsweise @arquillian-weld-ee-embedded@).
+# Klicke auf den OK-Knopf.
 
-Hier ist ein Screenshot des Maven Profil Selector Dialogs, welcher die aktivierten Profile anzeigt:
+Hier ist ein Screenshot des Maven-Profil-Selector-Dialogs, welcher die aktivierten Profile anzeigt:
 
 !/images/guides/arquillian_tutorial_maven_profile_selector.png!
 
 Ist das Profil einmal aktiviert, sollte der Test wieder erfolgreich ausgeführt werden können.
 
-Du weißt schon, dass der Test im Weld EE Embedded Container funktioniert. Nun wechseln wir auf den GlassFish Embedded indem die o.g. Schritte durchgeführt werden. Diesmal aktiviere allerdings das @arquillian-glassfish-embedded@ Profil. Führe den Test erneut aus. Du solltest auf der Konsole sehen, wie der GlassFish startet, gefolgt von einer erneuten *(greenbar)green bar*!
+Du weißt schon, dass der Test im Weld-EE-Embedded-Container funktioniert. Nun wechseln wir auf den GlassFish Embedded, indem die o.g. Schritte durchgeführt werden. Diesmal aktiviere allerdings das @arquillian-glassfish-embedded@-Profil. Führe den Test erneut aus. Du solltest auf der Konsole sehen, wie der GlassFish startet, gefolgt von einer erneuten *(greenbar)green bar*!
 
-Du hast die Tests nun auf verschiedenen embedded Containern ausgeführt. Einem CDI Container (Weld) und einem Java EE Container (GlassFish). Bei beiden handelte es sich um Container, welche in der gleichen JVM wie die Tests laufen. Um wirklich sicher zu sein, müssen die Tests in einem alleinstehenden Container erfolgreich durchlaufen werden. Daher wechseln wir zum JBoss AS.
+Du hast die Tests nun auf verschiedenen Embedded-Containern ausgeführt, einem CDI-Container (Weld) und einem Java-EE-Container (GlassFish). Bei beiden handelte es sich um Container, welche in der gleichen JVM wie die Tests laufen. Um wirklich sicher zu sein, müssen die Tests in einem alleinstehenden Container erfolgreich durchlaufen werden. Daher wechseln wir zum JBoss AS.
 
 Um die Tests in einer alleinstehenden Instanz vom JBoss AS laufen zu lassen, muss diese erst einmal konfiguriert werden. Dies geschieht entweder:
 
 # durch Herunterladen und Entpacken der Distribution an eine Stelle im Dateisystem außerhalb des Projekts oder
 # du lässt Maven beides beim Bauen des Projekts selber machen.
 
-Folge diesen Schritten um JBoss AS 7 außerhalb des Projekts aufzusetzen:
+Folge diesen Schritten, um JBoss AS 7 außerhalb des Projekts aufzusetzen:
 
 # "Lade JBoss AS 7 herunter":as7_download
-(Versichere Dich, dass die Version die Du auswählst genau zu der Version passt, die Du in Deinem @pom.xml@ für @<artifactId>jboss-as-arquillian-container-managed</artifactId>@ angegeben hast!)
+(Versichere Dich, dass die Version, die Du auswählst, genau zu der Version passt, die Du in Deinem @pom.xml@ für @<artifactId>jboss-as-arquillian-container-managed</artifactId>@ angegeben hast!)
 # Packe das Archiv aus
-# (optional) Setze die @JBOSS_HOME@ Umgebungs-Variable auf den Pfad des ausgepackten Archivs.
+# (optional) Setze die @JBOSS_HOME@-Umgebungs-Variable auf den Pfad des ausgepackten Archivs.
 
-Um Maven die Arbeit beim Bauen machen zu lassen, musst Du das folgenden XML Fragment unter das schließende @<id>@ Element des @arquillian-jbossas-managed@ Profils einfügen:
+Um Maven die Arbeit beim Bauen machen zu lassen, musst Du das folgenden XML-Fragment unter das schließende @<id>@ Element des @arquillian-jbossas-managed@-Profils einfügen:
 
 div(filename). pom.xml
 
@@ -925,7 +924,7 @@ bc(prettify).. <!-- clip -->
 </build>
 <!-- clip -->
 
-p. Die managed JBoss AS 7 Instanz benötigt ein wenig Arquillian Konfiguration. Erstelle eine Datei mit dem Namen arquillian.xml unter @src/test/resources@ und ändere den Wert des @jbossHome@ Propertie auf das Verzeichnis in das Du den JBoss AS 7 installiert hast. Wenn Du Maven die Arbeit beim Bauen machen lässt (maven dependency plugin) lautet der Wert @target/jboss-as-7.1.1.Final@.
+p. Die Managed-JBoss-AS-7-Instanz benötigt ein wenig Arquillian-Konfiguration. Erstelle eine Datei mit dem Namen arquillian.xml unter @src/test/resources@ und ändere den Wert des @jbossHome@-Property auf das Verzeichnis, in das Du den JBoss AS 7 installiert hast. Wenn Du Maven die Arbeit beim Bauen machen lässt (maven dependency plugin), lautet der Wert @target/jboss-as-7.1.1.Final@.
 
 div(filename). src/test/resources/arquillian.xml
 
@@ -941,8 +940,8 @@ bc(prettify).. <arquillian xmlns="http://jboss.org/schema/arquillian"
     </container>
 </arquillian>
 
-p. Wechsele jetzt das aktive Maven Profil auf @arquillian-jbossas-managed@ und lass die Tests ein letztes mal laufen. Du solltest in der Konsole sehen, wie der JBoss AS 7 startet und ..... dann eine erneute *(greenbar)green bar* erscheint!
+p. Wechsele jetzt das aktive Maven-Profil auf @arquillian-jbossas-managed@ und lass die Tests ein letztes mal laufen. Du solltest in der Konsole sehen, wie der JBoss AS 7 startet und ..... dann eine erneute *(greenbar)green bar* erscheint!
 
-p(info). %Die Meldungen von System.out werden direkt ins Server log und nicht auf die Konsole geschrieben.%
+p(info). %Die Meldungen von System.out werden direkt ins Serverlog und nicht auf die Konsole geschrieben.%
 
-Das ist _der gleiche_ Test. Nur diesmal in einem alleinstehenden (nicht eingebetteten) Javva EE Container. Arquillian packt das Test Archiv, deployt es auf den Container als Java EE Archiv und führt den Test remote durch. Erfasst dann die Ergebnisse und stellt sie der Eclipse JUnit Ergebnis View (oder dem Maven Surefire Plugin) zur Verfügung.
+Das ist _der gleiche_ Test, nur diesmal in einem alleinstehenden (nicht eingebetteten) Java-EE-Container. Arquillian packt das Testarchiv, deployt es auf den Container als Java-EE-Archiv und führt den Test remote durch, erfasst dann die Ergebnisse und stellt sie der Eclipse-JUnit-Ergebnis-View (oder dem Maven-Surefire-Plugin) zur Verfügung.


### PR DESCRIPTION

#### Short description of what this resolves:
Hard-to-read German version because of missing commas and hyphens

#### Changes proposed in this pull request:

-
-
-


**Fixes**: #
