### PR TITLE
Translated some English parts to German language in documentation

### DIFF
--- a/guides/testing_java_persistence_de.textile
+++ b/guides/testing_java_persistence_de.textile
@@ -455,7 +455,7 @@ java.util.logging.ConsoleHandler.formatter=java.util.logging.SimpleFormatter
 java.util.logging.SimpleFormatter.format=%4$s: %5$s%n
 java.util.logging.ConsoleHandler.level=FINEST
 
-p. Die Persistence Unit ist test-persistence.xml und zeigt auf eine DataSource mit dem Namenjdbc/arquillian. Wo ist das angelegt? Das ist etwas, was der Arquillian Container Adapter angeben muss.
+p. Die Persistence Unit ist test-persistence.xml und zeigt auf eine DataSource mit dem Namen jdbc/arquillian. Wo ist das angelegt? Das ist etwas, was der Arquillian Container Adapter angeben muss.
 
 Wir möchten mit Hilfe der GlassFish APIs einen JDBC Connection Pool und zugehörige Rssourcen anlegen. Allerdings möchten wir damit keinen Code schreiben. Wir möchten es lediglich anlegen. An dieser Stelle kommt Aequillian ins Spiel.
 
@@ -558,7 +558,7 @@ bc(prettify).. <!-- clip -->
 <!-- clip -->
 
 p(warning). %Falls du eine Datenbank (z.B. MySQL) verwenden möchtest, die nicht schon mit dem Application Server mitgeliefert wird, musst du die Client Bibliotheken ebenfalls zum Classpath hinzufügen.
-Wirf einen Blick auf das "sample project":http://github.com/arquillian/arquillian-examples/tree/master/arquillian-persistence-tutorial um ein Beispiel für die Verwendung der H2 Datenbank anstelle der mitgelieferten Derby Datenbank zu bekommen.%
+Wirf einen Blick auf das "Beispielprojekt":http://github.com/arquillian/arquillian-examples/tree/master/arquillian-persistence-tutorial um ein Beispiel für die Verwendung der H2 Datenbank anstelle der mitgelieferten Derby Datenbank zu bekommen.%
 
 p. Jetzt füge (oder ändere) das Profil für den Embedded Glassfish:
 
@@ -623,7 +623,7 @@ Wenn alle Schritte durchgeführt sind, kannst du die Tests ausführen, in dem du
 
 bc(command). $ mvn clean test
 
-Das Maven Profil für den Embedded Glassfish ist standardmäßig aktiviert (as is the container adapter configuration in arquillian.xml). Ausschnitte des Tests sind unten zu sehen.
+Das Maven Profil für den Embedded Glassfish ist standardmäßig aktiviert (wie die Containeradapter-Konfiguration in arquillian.xml). Ausschnitte des Tests sind unten zu sehen.
 
 bc(output). ...
 Running org.arquillian.example.GamePersistenceTest
@@ -673,15 +673,15 @@ Found 3 games (using Criteria):
 
 p. *Glückwunsch!* *(greenbar)Green bar*! _Jetzt ist es ein richtiger Integrationstest!_
 
-p(important). %Sobald du fortgeschrittene JPA Mappings wie zum Beispiel lazy loading und fetch groups einfügst, könntest du in Fehler oder Warnungen laufen, die durch . As you introduce advanced JPA mappings, such as lazy loading and fetch groups, you may run into errors or warnings caused by Embedded GlassFish interfering with the necessary weaving step in EclipseLink. Additional build configuration is required to workaround this problem. Refer to "Markus Eisele's blog":http://blog.eisele.net/2012/01/arquillian-with-netbeans-glassfish_18.html for instructions. You won't have this problem when using a managed or remote container adapter.%
+p(important). %Sobald du fortgeschrittene JPA Mappings wie zum Beispiel _lazy loading_ oder _fetch groups_ einfügst, könntest du in Fehler oder Warnungen laufen, die durch Störungen zwischen dem Embedded GlassFish und dem notwendigen _Weaving_-Schritt in EclipseLink hervorgerufen werden. Zusätzliche Buildkonfiguration ist nötig, um dieses Problem zu beheben. Wende dich für Anweisungen an "Markus Eisele's blog":http://blog.eisele.net/2012/01/arquillian-with-netbeans-glassfish_18.html. Dieses Problem tritt bei der Verwendung eines Managed oder Remote Containeradapters nicht auf.%
 
 h3. Dem Test auf dem JBoss AS 7 ausführen
 
 Den vorherigen Test können wir auch mit ein paar einfachen Classpath Änderungen auf dem JBoss ausführen.
 
-We'll first need a different Persistence Unit definition that specifies a DataSource that's available on JBoss AS (and optionally sets some Hibernate configuration settings).
+Zunächst benötigen wir eine andere Persistence Unit Definition, die eine in JBoss AS verfügbare DataSource festlegt (und optionalerweise Hibernate-Konfigurationseinstellungen).
 
-If you were using JBoss AS 7.0, you'd need to "setup a DataSource manually in the JBoss AS configuration":https://docs.jboss.org/author/display/AS7/Admin+Guide#AdminGuide-Datasources or leverage the built-in DataSource, java:jboss/datasources/ExampleDS. Here's the Persistence Unit descriptor for JBoss AS 7.0 that uses the built-in DataSource.
+Falls du JBoss AS 7.0 verwendenden würdest, müsstest du "eine DataSource manuell in der JBoss AS Konfiguration aufsetzen":https://docs.jboss.org/author/display/AS7/Admin+Guide#AdminGuide-Datasources oder die eingebaute DataSource aushebeln. Hier ist der Persistence Unit Deskriptor für JBoss AS 7.0, der die eingebaute DataSource verwendet.
 
 div(filename). src/test/resources-jbossas-managed/test-persistence.xml
 
@@ -722,7 +722,7 @@ bc(prettify). <?xml version="1.0" encoding="UTF-8"?>
     </datasource>
 </datasources>
 
-p(info). %JBoss AS 7.1 bringt von Haus aus die H2 Datenbank mit. Um eine andere Datenbank zu verwenden, musst du den jeweiligen Treiber zur Installation hinzufügen (wie im "DataSources Kapitel des JBoss AS 7.1 Reference Guides beschrieben":https://docs.jboss.org/author/display/AS71/Admin+Guide#AdminGuide-Datasources.%
+p(info). %JBoss AS 7.1 bringt von Haus aus die H2 Datenbank mit. Um eine andere Datenbank zu verwenden, musst du den jeweiligen Treiber zur Installation hinzufügen (wie im "DataSources Kapitel des JBoss AS 7.1 Reference Guides":https://docs.jboss.org/author/display/AS71/Admin+Guide#AdminGuide-Datasources beschrieben.%
 
 Wir müssen unsere Persistence Unit anpassen, um die neue DataSource zu verwenden:
 
@@ -800,4 +800,4 @@ Und das Beste daran ist: Du kannst diesen Test natürlich auch in deiner IDE aus
 
 *Genieße diesen klasse Weg zum Testen von JPA!*
 
-p(info). %WEs befand sich sehr viel Installation in diesem Guide. Beachte allerdings, dass wir auch keinen Stein unangetastet gelassen haben. hile there was a lot of setup in this guide, recognize it's because that we left no stone unturned. To remind you of the benefits of Arquillian, just look back at how simple the test case is. Erinnere dich daran, dass wir an keinen Java EE 6 Container und keine JPA 2 Implementierung gebunden sind.%
+p(info). %WEs befand sich sehr viel Installation in diesem Guide. Beachte allerdings, dass wir auch keinen Stein unangetastet gelassen haben. Um dich an die Vorzüge von Arquillian zu erinnern, betrachte wie einfach der Testfall ist. Erinnere dich daran, dass wir an keinen Java EE 6 Container und keine JPA 2 Implementierung gebunden sind.%


### PR DESCRIPTION
#### Short description of what this resolves:
The German translation of the _Testing Java Persistence_ documentation article contains some untranslated phrases, which disturbs the reading flow. I translated these parts into the German language.

#### Changes proposed in this pull request:

- Translated phrases into German language
- Fixed problems with half-finished / truncated sentences

**Fixes**: #390
