### PR TITLE
Changed style of code inside of info panel

### DIFF
--- a/blog/smart-testing-0.0.1.textile
+++ b/blog/smart-testing-0.0.1.textile
@@ -57,7 +57,7 @@ bc(prettify).. $ mvn clean verify -Dsmart.testing=new,changed,affected
 p. This will execute the build running only those tests which are falling into selected categories, based on your local changes.
 
 p(info). %For the CI environment, such as Jenkins, you can pass commit hashes using environment variables. For example: 
-@$ mvn verify -Dsmart.testing=affected -Dscm.range.head=GIT_COMMIT -Dscm.range.tail=GIT_PREVIOUS_COMMIT@%
+<code class="prettify">$ mvn verify -Dsmart.testing=affected -Dscm.range.head=GIT_COMMIT -Dscm.range.tail=GIT_PREVIOUS_COMMIT</code>%
 
 This will optimize tests based on the changes between the current commit and the one against which the previous build was run.
 


### PR DESCRIPTION
Instead of:
![original-info-panel](https://user-images.githubusercontent.com/1510709/30470068-940e79ae-99f3-11e7-88ae-71d6c47b2924.png)
it is changed to:
![new-info-panel](https://user-images.githubusercontent.com/1510709/30470104-ae2d7678-99f3-11e7-9174-197cdaaedd78.png)
Unfortunately, I wasn't able to fix the overflowing on a smaller screen - it is probably limited by the info panel. :-/
