### PR TITLE
Fix typo

### DIFF
--- a/guides/getting_started_fr.textile
+++ b/guides/getting_started_fr.textile
@@ -420,7 +420,7 @@ p. Venons-en aux fameux ajustements. Un cas de test Arquillian doit contenir tro
 
 # une annotation @@RunWith(Arquillian.class)@ sur la classe
 # Une méthode statique retournant une archive ShrinkWrap annotée avec @@Deployment@
-# Au mois une méthode annotée avec @@Test@
+# Au moins une méthode annotée avec @@Test@
 
 L'annotation @@RunWith@ indique à JUnit d'utiliser Arquillian comme contrôleur pour le test. Arquillian cherche alors une méthode statique annotée avec @@Deployment@ pour récupérer l'archive de test (i.e. le micro-déploiement). C'est là que l'effet magique se produit en faisant en sorte que toutes les méthodes @@Test soient exécutées dans l'environnement du conteneur.
 


### PR DESCRIPTION
#### Short description of what this resolves:
It's just a fix for a typo in french language. 

"At least" should be translate by "Au moins"

#### Changes proposed in this pull request:

- Just fixed the typo

**Fixes**: N/A
