### PR TITLE
fix #412: adds check for blog post type.

### DIFF
--- a/src/test/java/org/arquillian/tests/pagetests/BlogPageTest.java
+++ b/src/test/java/org/arquillian/tests/pagetests/BlogPageTest.java
@@ -1,5 +1,6 @@
 package org.arquillian.tests.pagetests;
 
+import org.arquillian.tests.utilities.BlogVerifier;
 import org.arquillian.tests.pom.pageObjects.BlogPage;
 import org.arquillian.tests.pom.pageObjects.MainPage;
 import org.arquillian.tests.pom.pageObjects.StandalonePage;
@@ -12,6 +13,11 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(Arquillian.class)
 @RunAsClient
@@ -40,10 +46,11 @@ public class BlogPageTest {
         mainPage.menu()
             .navigate().to("Blog");
 
-        blogPage.releaseBlog()
-            .verify()
-                .hasTitle()
-                .hasReleaseNotes();
+        List<WebElement> releaseBlogs = blogPage.releaseBlogs();
+
+        assertThat(releaseBlogs)
+                .allSatisfy(BlogVerifier::hasTitle)
+                .allSatisfy(BlogVerifier::hasReleaseNotes);
     }
 
     @Test
@@ -67,10 +74,11 @@ public class BlogPageTest {
         fetchedBlogPage.verify().hasTitle("Arquillian Blog · Arquillian")
             .hasContent();
 
-        blogPage.releaseBlog()
-            .verify()
-                .hasTitle()
-                .hasReleaseNotes();
+        List<WebElement> releaseBlogs = blogPage.releaseBlogs();
+
+        assertThat(releaseBlogs)
+                .allSatisfy(BlogVerifier::hasTitle)
+                .allSatisfy(BlogVerifier::hasReleaseNotes);
     }
 
     @Test
@@ -81,16 +89,16 @@ public class BlogPageTest {
         blogPage.cloudTag()
             .navigate().to("drone");
 
-        blogPage.releaseBlog()
-            .verify()
-                .hasAnnouncementBanner(true);
+        List<WebElement> releaseBlogs = blogPage.releaseBlogs();
+
+        assertThat(releaseBlogs).anySatisfy(BlogVerifier::haveAnnouncementBanner);
 
         blogPage.newAnnouncementBanner()
             .navigate().to("Check our latest announcement");
 
-        blogPage.releaseBlog()
-            .verify()
-                .hasAnnouncementBanner(false);
+        WebElement newReleaseBlog = blogPage.releaseBlogs().get(0);
+
+        assertThat(newReleaseBlog).satisfies(BlogVerifier::doesNotHaveAnnouncementBanner);
     }
 
     @Test
@@ -101,8 +109,9 @@ public class BlogPageTest {
         blogPage.cloudTag()
                 .navigate().to("nonrelease");
 
-        blogPage.nonReleaseBlog()
-                .verify()
-                    .hasTitle();
+        List<WebElement> nonReleaseBlogs = blogPage.nonReleaseBlogs();
+
+        assertThat(nonReleaseBlogs)
+                .allSatisfy(BlogVerifier::hasTitle);
     }
 }

--- a/src/test/java/org/arquillian/tests/pagetests/BlogPageTest.java
+++ b/src/test/java/org/arquillian/tests/pagetests/BlogPageTest.java
@@ -92,4 +92,17 @@ public class BlogPageTest {
             .verify()
             .hasAnnouncementBanner(false);
     }
+
+    @Test
+    public void should_ignore_release_notes_for_non_release_blog_posts() throws Exception {
+        mainPage.menu()
+                .navigate().to("Blog");
+
+        blogPage.cloudTag()
+                .navigate().to("nonrelease");
+
+        blogPage.blogContent()
+                .verify()
+                .hasReleaseNotes();
+    }
 }

--- a/src/test/java/org/arquillian/tests/pagetests/BlogPageTest.java
+++ b/src/test/java/org/arquillian/tests/pagetests/BlogPageTest.java
@@ -35,12 +35,12 @@ public class BlogPageTest {
     }
 
     @Test
-    public void should_have_content_listing_all_blogs_with_title_and_release_notes() throws Exception {
+    public void should_have_content_listing_all_release_blogs_with_title_and_release_notes() throws Exception {
 
         mainPage.menu()
             .navigate().to("Blog");
 
-        blogPage.blogContent()
+        blogPage.releaseBlog()
             .verify()
                 .hasTitle()
                 .hasReleaseNotes();
@@ -53,7 +53,7 @@ public class BlogPageTest {
 
         blogPage.sidebar()
             .verify()
-            .hasSubSectionHeaders("Subscribe to the Arquillian Blog", "Latest Posts", "Popular Posts", "Tags");
+                .hasSubSectionHeaders("Subscribe to the Arquillian Blog", "Latest Posts", "Popular Posts", "Tags");
     }
 
     @Test
@@ -67,7 +67,7 @@ public class BlogPageTest {
         fetchedBlogPage.verify().hasTitle("Arquillian Blog · Arquillian")
             .hasContent();
 
-        blogPage.blogContent()
+        blogPage.releaseBlog()
             .verify()
                 .hasTitle()
                 .hasReleaseNotes();
@@ -81,16 +81,16 @@ public class BlogPageTest {
         blogPage.cloudTag()
             .navigate().to("drone");
 
-        blogPage.blogContent()
+        blogPage.releaseBlog()
             .verify()
-            .hasAnnouncementBanner(true);
+                .hasAnnouncementBanner(true);
 
         blogPage.newAnnouncementBanner()
             .navigate().to("Check our latest announcement");
 
-        blogPage.blogContent()
+        blogPage.releaseBlog()
             .verify()
-            .hasAnnouncementBanner(false);
+                .hasAnnouncementBanner(false);
     }
 
     @Test
@@ -101,8 +101,8 @@ public class BlogPageTest {
         blogPage.cloudTag()
                 .navigate().to("nonrelease");
 
-        blogPage.blogContent()
+        blogPage.nonReleaseBlog()
                 .verify()
-                .hasReleaseNotes();
+                    .hasTitle();
     }
 }

--- a/src/test/java/org/arquillian/tests/pom/fragmentObjects/BlogFragment.java
+++ b/src/test/java/org/arquillian/tests/pom/fragmentObjects/BlogFragment.java
@@ -34,19 +34,24 @@ public class BlogFragment {
         public BlogVerifier hasReleaseNotes() {
             for (WebElement item : fragmentItems) {
                 try {
-                    WebElement releaseNoteTitle =
-                        item.findElement(By.xpath(".//h3[contains(text(),'Release notes and resolved issues')]"));
-                    List<WebElement> releaseNoteContents = item.findElements(By.xpath(".//dl"));
+                    WebElement releaseTag = item.findElement(By.linkText("release"));
+                    try {
+                        WebElement releaseNoteTitle =
+                                item.findElement(By.xpath(".//h3[contains(text(),'Release notes and resolved issues')]"));
+                        List<WebElement> releaseNoteContents = item.findElements(By.xpath(".//dl"));
 
-                    assertThat(releaseNoteTitle.isDisplayed() && releaseNoteContents.stream()
-                        .allMatch(WebElement::isDisplayed)).isTrue();
+                        assertThat(releaseNoteTitle.isDisplayed() && releaseNoteContents.stream()
+                                .allMatch(WebElement::isDisplayed)).isTrue();
 
+                    } catch (NoSuchElementException e) {
+                        throw new NoSuchElementException(
+                                "Missing release notes for blog post titled: " + getBlogTitle(item).getText() + ".\n" +
+                                        "If the release was performed manually, this happen because we forgot to: \n" +
+                                        "- close the milestone on GitHub or release version on JIRA\n" +
+                                        "- push tag to the upstream repo after releasing to Maven Central (git push origin --tags)");
+                    }
                 } catch (NoSuchElementException e) {
-                    throw new NoSuchElementException(
-                        "Missing release notes for blog post titled: " + getBlogTitle(item).getText() + ".\n" +
-                                "If the release was performed manually, this happen because we forgot to: \n" +
-                                "- close the milestone on GitHub or release version on JIRA\n" +
-                                "- push tag to the upstream repo after releasing to Maven Central (git push origin --tags)");
+                    // Ignore if non-release blog post
                 }
             }
             return this;

--- a/src/test/java/org/arquillian/tests/pom/fragmentObjects/BlogFragment.java
+++ b/src/test/java/org/arquillian/tests/pom/fragmentObjects/BlogFragment.java
@@ -33,8 +33,7 @@ public class BlogFragment {
 
         public BlogVerifier hasReleaseNotes() {
             for (WebElement item : fragmentItems) {
-                try {
-                    WebElement releaseTag = item.findElement(By.linkText("release"));
+                if (hasTypeRelease(item)) {
                     try {
                         WebElement releaseNoteTitle =
                                 item.findElement(By.xpath(".//h3[contains(text(),'Release notes and resolved issues')]"));
@@ -50,11 +49,18 @@ public class BlogFragment {
                                         "- close the milestone on GitHub or release version on JIRA\n" +
                                         "- push tag to the upstream repo after releasing to Maven Central (git push origin --tags)");
                     }
-                } catch (NoSuchElementException e) {
-                    // Ignore if non-release blog post
                 }
             }
             return this;
+        }
+
+        private boolean hasTypeRelease(WebElement item) {
+            try {
+                item.findElement(By.linkText("release"));
+                return true;
+            } catch (NoSuchElementException e) {
+                return false;
+            }
         }
 
         public BlogVerifier hasAnnouncementBanner(boolean status) {

--- a/src/test/java/org/arquillian/tests/pom/fragmentObjects/BlogFragment.java
+++ b/src/test/java/org/arquillian/tests/pom/fragmentObjects/BlogFragment.java
@@ -1,14 +1,9 @@
 package org.arquillian.tests.pom.fragmentObjects;
 
+import org.arquillian.tests.utilities.BlogVerifier;
 import org.arquillian.tests.utilities.PageNavigator;
 import org.jboss.arquillian.graphene.fragment.Root;
-import org.openqa.selenium.By;
-import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebElement;
-
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 public class BlogFragment {
 
@@ -17,67 +12,6 @@ public class BlogFragment {
 
     public BlogVerifier verify() {
         return new BlogVerifier();
-    }
-
-    public class BlogVerifier {
-
-        final List<WebElement> fragmentItems = contentRoot.findElements(By.cssSelector("[class='post']"));
-
-        public BlogVerifier hasTitle() {
-            for (WebElement blog : fragmentItems) {
-                WebElement blogTitle = getBlogTitle(blog);
-                assertThat(blogTitle.isDisplayed()).isTrue();
-            }
-            return this;
-        }
-
-        public BlogVerifier hasReleaseNotes() {
-            for (WebElement item : fragmentItems) {
-                if (hasTypeRelease(item)) {
-                    try {
-                        WebElement releaseNoteTitle =
-                                item.findElement(By.xpath(".//h3[contains(text(),'Release notes and resolved issues')]"));
-                        List<WebElement> releaseNoteContents = item.findElements(By.xpath(".//dl"));
-
-                        assertThat(releaseNoteTitle.isDisplayed() && releaseNoteContents.stream()
-                                .allMatch(WebElement::isDisplayed)).isTrue();
-
-                    } catch (NoSuchElementException e) {
-                        throw new NoSuchElementException(
-                                "Missing release notes for blog post titled: " + getBlogTitle(item).getText() + ".\n" +
-                                        "If the release was performed manually, this happen because we forgot to: \n" +
-                                        "- close the milestone on GitHub or release version on JIRA\n" +
-                                        "- push tag to the upstream repo after releasing to Maven Central (git push origin --tags)");
-                    }
-                }
-            }
-            return this;
-        }
-
-        private boolean hasTypeRelease(WebElement item) {
-            try {
-                item.findElement(By.linkText("release"));
-                return true;
-            } catch (NoSuchElementException e) {
-                return false;
-            }
-        }
-
-        public BlogVerifier hasAnnouncementBanner(boolean status) {
-            try {
-                WebElement announcementBanner = contentRoot.findElement(By.partialLinkText("Check our latest announcement"));
-                assertThat(announcementBanner.isDisplayed()).isEqualTo(status);
-            } catch (NoSuchElementException e) {
-                if(status) {
-                    throw new NoSuchElementException("Missing announcement banner for the blog post.", e);
-                }
-            }
-            return this;
-        }
-
-        private WebElement getBlogTitle(WebElement blog) {
-            return blog.findElement(By.cssSelector("[class='title'] a"));
-        }
     }
 
     public PageNavigator navigate() {

--- a/src/test/java/org/arquillian/tests/pom/pageObjects/BlogPage.java
+++ b/src/test/java/org/arquillian/tests/pom/pageObjects/BlogPage.java
@@ -22,7 +22,11 @@ public class BlogPage {
     @FindBy(css = "[class = 'tag-cloud']")
     private CloudTagFragment cloudTag;
 
-    public BlogFragment blogContent() {
+    public BlogFragment releaseBlog() {
+        return blogContent;
+    }
+
+    public BlogFragment nonReleaseBlog() {
         return blogContent;
     }
 

--- a/src/test/java/org/arquillian/tests/pom/pageObjects/BlogPage.java
+++ b/src/test/java/org/arquillian/tests/pom/pageObjects/BlogPage.java
@@ -6,7 +6,10 @@ import org.arquillian.tests.pom.fragmentObjects.SideBarFragment;
 import org.arquillian.tests.utilities.PageVerifier;
 import org.jboss.arquillian.drone.api.annotation.Drone;
 import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
+
+import java.util.List;
 
 public class BlogPage {
 
@@ -22,13 +25,11 @@ public class BlogPage {
     @FindBy(css = "[class = 'tag-cloud']")
     private CloudTagFragment cloudTag;
 
-    public BlogFragment releaseBlog() {
-        return blogContent;
-    }
+    @FindBy(xpath = ".//a[contains(text(),'release')]/ancestor::article")
+    private List<WebElement> releaseBlogPosts;
 
-    public BlogFragment nonReleaseBlog() {
-        return blogContent;
-    }
+    @FindBy(xpath = ".//a[contains(text(),'nonrelease')]/ancestor::article")
+    private List<WebElement> nonReleaseBlogPosts;
 
     public SideBarFragment sidebar() {
         return sidebar;
@@ -44,5 +45,13 @@ public class BlogPage {
 
     public BlogFragment newAnnouncementBanner() {
         return blogContent;
+    }
+
+    public List<WebElement> releaseBlogs() {
+        return releaseBlogPosts;
+    }
+
+    public List<WebElement> nonReleaseBlogs() {
+        return nonReleaseBlogPosts;
     }
 }

--- a/src/test/java/org/arquillian/tests/utilities/BlogVerifier.java
+++ b/src/test/java/org/arquillian/tests/utilities/BlogVerifier.java
@@ -1,0 +1,71 @@
+package org.arquillian.tests.utilities;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.WebElement;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class BlogVerifier {
+
+    public static void hasTitle(WebElement blog) {
+        WebElement blogTitle = getBlogTitle(blog);
+        assertThat(blogTitle.isDisplayed()).isTrue();
+    }
+
+    public static void hasReleaseNotes(WebElement item) {
+        if (hasTypeRelease(item)) {
+            try {
+                WebElement releaseNoteTitle =
+                        item.findElement(By.xpath(".//h3[contains(text(),'Release notes and resolved issues')]"));
+                List<WebElement> releaseNoteContents = item.findElements(By.xpath(".//dl"));
+
+                assertThat(releaseNoteTitle.isDisplayed() && releaseNoteContents.stream()
+                        .allMatch(WebElement::isDisplayed)).isTrue();
+
+            } catch (NoSuchElementException e) {
+                throw new NoSuchElementException(
+                        "Missing release notes for blog post titled: " + getBlogTitle(item).getText() + ".\n" +
+                                "If the release was performed manually, this happen because we forgot to: \n" +
+                                "- close the milestone on GitHub or release version on JIRA\n" +
+                                "- push tag to the upstream repo after releasing to Maven Central (git push origin --tags)");
+            }
+        }
+    }
+
+    public static void haveAnnouncementBanner(WebElement item) {
+        try {
+            WebElement announcementBanner = item.findElement(By.partialLinkText("Check our latest announcement"));
+            assertThat(announcementBanner.isDisplayed()).isTrue();
+        } catch (NoSuchElementException e) {
+            // Ignore if no announcement banner
+        }
+    }
+
+    public static void doesNotHaveAnnouncementBanner(WebElement item) {
+        WebElement announcementBanner = null;
+        try {
+            announcementBanner = item.findElement(By.partialLinkText("Check our latest announcement"));
+            assertThat(announcementBanner.isDisplayed()).isFalse();
+        } catch (NoSuchElementException e) {
+            assertThat(announcementBanner).isNull();
+        }
+    }
+
+    private static boolean hasTypeRelease(WebElement item) {
+        try {
+            item.findElement(By.linkText("release"));
+            return true;
+        } catch (NoSuchElementException e) {
+            return false;
+        }
+    }
+
+    private static WebElement getBlogTitle(WebElement blog) {
+        return blog.findElement(By.cssSelector("[class='title'] a"));
+    }
+}
+
+


### PR DESCRIPTION
#### Short description of what this resolves:
Ignores release notes validations for blog post that are of non-release type.

#### Changes proposed in this pull request:

- Adds check for blog-post type before validating presence of release-notes.

**Fixes**: #412 
