### PR TITLE
fix: updated nokogiri to 1.8.1 because of a known critical severity security vulnerability

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,7 +53,7 @@ gem 'jruby-openssl', '0.7.7', :platforms => :jruby
 gem 'rb-inotify', :platforms => [:ruby, :jruby]
 gem 'versionomy'
 gem 'rspec', '>= 2.9'
-gem 'nokogiri', '1.6.8'
+gem 'nokogiri', '1.8.1'
 gem 'ruby-progressbar'
 gem 'parallel'
 gem 'rmagick'


### PR DESCRIPTION
to get rid of this warning:
![image](https://user-images.githubusercontent.com/1510709/35923901-ceb171e2-0c21-11e8-9bc7-0fda67219719.png)
