### PR TITLE
fix(#434): copy .github-auth file to test-project-directory.

### DIFF
--- a/_scripts/verify.sh
+++ b/_scripts/verify.sh
@@ -26,6 +26,7 @@ if [ ! -d ${TEST_PROJECT_DIRECTORY} ]; then
     fi
 
     git ${VARIABLE_TO_SET_GH_PATH} worktree add -b functional-tests ${TEST_PROJECT_DIRECTORY} origin/functional-tests;
+    cp ${ARQUILLIAN_PROJECT_DIR}/.github-auth ${TEST_PROJECT_DIRECTORY}
 fi
 
 ### execute UI tests


### PR DESCRIPTION
#### Short description of what this resolves:

Copies `.github-auth` to the test-project directory to make it available for the functional tests.

**Fixes**: #434
