### PR TITLE
fix: nil references while generating content

### DIFF
--- a/_ext/guide.rb
+++ b/_ext/guide.rb
@@ -103,7 +103,10 @@ module Awestruct
                 trans_page.language.code = trans_lang
                 if !trans_page.translators.nil?
                   trans_page.translators.each do |username|
-                    page.site.identities.lookup(username).translator = true
+                    trans_user = page.site.identities.lookup(username)
+                    if trans_user
+                      trans_user.translator = true
+                    end
                   end
                 end
 

--- a/_ext/releases.rb
+++ b/_ext/releases.rb
@@ -76,7 +76,14 @@ module Awestruct::Extensions::Releases
           else
             release_page.title ||= "#{component.name} #{release.version} Released"
           end
-          release_page.author ||= !post_author.nil? ? post_author : site.identities.lookup_by_contributor(release.released_by).username
+          if post_author
+            release_page.author ||= post_author
+          else
+            contributor = site.identities.lookup_by_contributor(release.released_by)
+            if contributor
+              release_page.author ||= contributor.username
+            end
+          end
           if post_date
             release_page.date ||= post_date
           else


### PR DESCRIPTION
While building from an empty docker container I had several nil reference issues; potentially because I don't have authorization to view the github teams. These code changes address those issues.