### PR TITLE
fix: incorrect URL including '[bot]'

### DIFF
--- a/_ext/identities/github.rb
+++ b/_ext/identities/github.rb
@@ -4,6 +4,7 @@ require 'digest/md5'
 require 'parallel'
 require 'rmagick'
 require 'ostruct'
+require 'cgi'
 
 require_relative '../common.rb'
 
@@ -121,7 +122,7 @@ module Identities
           filter.values.select{|author| !author.github_id.nil? and !visited.include? author.github_id}.each do |author|
             github_id = author.github_id
             puts "Manually adding #{author.name} (#{github_id}) as a contributor"
-            url = USER_URL_TEMPLATE % [ github_id ]
+            url = USER_URL_TEMPLATE % [ CGI.escape(github_id) ]
             user = RestClient.get(url, :accept => 'application/json').content
             identity = identities.lookup_by_github_id(github_id, true)
             github_acct_to_identity(user, author, identity)


### PR DESCRIPTION
This escapes GitHub IDs in URLs so fixes the following error in the Travis build: https://travis-ci.org/arquillian/arquillian.github.io/builds/422520504#L139